### PR TITLE
Feat: Implement in-app logging for API calls.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,12 @@
             android:exported="false"
             android:label="@string/title_activity_settings"
             android:parentActivityName=".MainActivity" />
+        <activity
+            android:name=".utils.LogActivity"
+            android:label="Application Logs"
+            android:theme="@style/Theme.SpeakKey"
+            android:parentActivityName=".MainActivity">
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -31,6 +31,7 @@ import com.drgraff.speakkey.api.ChatGptApi;
 import com.drgraff.speakkey.api.WhisperApi;
 import com.drgraff.speakkey.inputstick.InputStickManager;
 import com.drgraff.speakkey.settings.SettingsActivity;
+import com.drgraff.speakkey.utils.AppLogManager;
 import com.drgraff.speakkey.utils.ThemeManager;
 import com.google.android.material.navigation.NavigationView;
 
@@ -369,17 +370,20 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         }
         
         Toast.makeText(this, "Transcribing audio...", Toast.LENGTH_SHORT).show();
+        AppLogManager.getInstance().addEntry("INFO", "Whisper: Starting transcription...", null);
         
         // Perform transcription in background
         new Thread(() -> {
             try {
                 String transcription = whisperApi.transcribe(audioFile);
+                AppLogManager.getInstance().addEntry("SUCCESS", "Whisper: Transcription successful", "Length: " + transcription.length());
                 mainHandler.post(() -> {
                     whisperText.setText(transcription);
                     Toast.makeText(MainActivity.this, "Transcription complete", Toast.LENGTH_SHORT).show();
                 });
             } catch (Exception e) {
                 Log.e(TAG, "Error transcribing audio", e);
+                AppLogManager.getInstance().addEntry("ERROR", "Whisper: Transcription failed", e.toString());
                 mainHandler.post(() -> {
                     // Show a more specific toast
                     String detailedErrorMessage = getString(R.string.error_transcribing);
@@ -430,11 +434,13 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         }
         
         Toast.makeText(this, "Sending to ChatGPT...", Toast.LENGTH_SHORT).show();
+        AppLogManager.getInstance().addEntry("INFO", "ChatGPT: Sending request...", null);
         
         // Send to ChatGPT in background
         new Thread(() -> {
             try {
                 String response = chatGptApi.getCompletion(transcript);
+                AppLogManager.getInstance().addEntry("SUCCESS", "ChatGPT: Response received", "Length: " + response.length());
                 mainHandler.post(() -> {
                     chatGptText.setText(response);
                     Toast.makeText(MainActivity.this, "Response received", Toast.LENGTH_SHORT).show();
@@ -446,6 +452,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                 });
             } catch (Exception e) {
                 Log.e(TAG, "Error getting ChatGPT response", e);
+                AppLogManager.getInstance().addEntry("ERROR", "ChatGPT: Request failed", e.toString());
                 mainHandler.post(() -> {
                     Toast.makeText(MainActivity.this, R.string.error_chatgpt, Toast.LENGTH_SHORT).show();
                 });
@@ -491,6 +498,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             // Already on home, just close drawer
         } else if (id == R.id.nav_settings) {
             Intent intent = new Intent(this, SettingsActivity.class);
+            startActivity(intent);
+        } else if (id == R.id.nav_view_logs) {
+            Intent intent = new Intent(this, com.drgraff.speakkey.utils.LogActivity.class);
             startActivity(intent);
         }
         

--- a/app/src/main/java/com/drgraff/speakkey/utils/AppLogManager.java
+++ b/app/src/main/java/com/drgraff/speakkey/utils/AppLogManager.java
@@ -1,0 +1,43 @@
+package com.drgraff.speakkey.utils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class AppLogManager {
+    private static AppLogManager instance;
+    private final List<LogEntry> logEntries;
+
+    private AppLogManager() {
+        logEntries = Collections.synchronizedList(new ArrayList<>());
+    }
+
+    public static synchronized AppLogManager getInstance() {
+        if (instance == null) {
+            instance = new AppLogManager();
+        }
+        return instance;
+    }
+
+    public void addEntry(String level, String message, String detail) {
+        // Add new entries at the beginning of the list so they appear at the top in the RecyclerView
+        logEntries.add(0, new LogEntry(System.currentTimeMillis(), level, message, detail));
+    }
+    
+    public void addEntry(LogEntry entry) {
+        logEntries.add(0, entry);
+    }
+
+    public List<LogEntry> getEntries() {
+        // Return a copy to prevent external modification issues if not using synchronized list directly
+        // However, for display in RecyclerView, direct reference might be fine if adapter is notified correctly
+        // For simplicity and safety, returning a copy is robust.
+        synchronized (logEntries) {
+            return new ArrayList<>(logEntries);
+        }
+    }
+
+    public void clearEntries() {
+        logEntries.clear();
+    }
+}

--- a/app/src/main/java/com/drgraff/speakkey/utils/LogActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/utils/LogActivity.java
@@ -1,0 +1,74 @@
+package com.drgraff.speakkey.utils; // Or com.drgraff.speakkey.ui if preferred
+
+import android.os.Bundle;
+import android.view.MenuItem;
+import android.widget.Button;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.drgraff.speakkey.R; // Ensure R is imported correctly
+
+import java.util.ArrayList;
+
+public class LogActivity extends AppCompatActivity {
+
+    private RecyclerView logRecyclerView;
+    private LogAdapter logAdapter;
+    private Button clearLogButton;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_log);
+
+        // Enable the Up button in the action bar
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true);
+            actionBar.setTitle("Application Log"); // Set a title for the activity
+        }
+
+        logRecyclerView = findViewById(R.id.log_recycler_view);
+        clearLogButton = findViewById(R.id.clear_log_button);
+
+        // Setup RecyclerView
+        logRecyclerView.setLayoutManager(new LinearLayoutManager(this));
+        // Initialize with an empty list, will be populated in onResume
+        logAdapter = new LogAdapter(new ArrayList<>()); 
+        logRecyclerView.setAdapter(logAdapter);
+
+        // Set up Clear Log button listener
+        clearLogButton.setOnClickListener(v -> {
+            AppLogManager.getInstance().clearEntries();
+            refreshLogView();
+        });
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        refreshLogView();
+    }
+
+    private void refreshLogView() {
+        if (logAdapter != null) {
+            logAdapter.updateLogEntries(AppLogManager.getInstance().getEntries());
+        }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        // Handle action bar item clicks here. The action bar will
+        // automatically handle clicks on the Home/Up button, so long
+        // as you specify a parent activity in AndroidManifest.xml.
+        if (item.getItemId() == android.R.id.home) {
+            finish(); // Go back to the previous activity
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+}

--- a/app/src/main/java/com/drgraff/speakkey/utils/LogAdapter.java
+++ b/app/src/main/java/com/drgraff/speakkey/utils/LogAdapter.java
@@ -1,0 +1,88 @@
+package com.drgraff.speakkey.utils;
+
+import android.graphics.Color;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.drgraff.speakkey.R; // Make sure R is imported from the correct package
+
+import java.util.List;
+
+public class LogAdapter extends RecyclerView.Adapter<LogAdapter.LogViewHolder> {
+
+    private List<LogEntry> logEntries;
+
+    public LogAdapter(List<LogEntry> logEntries) {
+        this.logEntries = logEntries;
+    }
+
+    @NonNull
+    @Override
+    public LogViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.list_item_log, parent, false);
+        return new LogViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull LogViewHolder holder, int position) {
+        LogEntry entry = logEntries.get(position);
+
+        holder.timestampTextView.setText(entry.getFormattedTimestamp());
+        holder.levelTextView.setText(entry.level);
+        holder.messageTextView.setText(entry.message);
+        
+        if (entry.detail != null && !entry.detail.isEmpty()) {
+            holder.detailTextView.setText(entry.detail);
+            holder.detailTextView.setVisibility(View.VISIBLE);
+        } else {
+            holder.detailTextView.setVisibility(View.GONE);
+        }
+
+        // Set color based on log level
+        switch (entry.level.toUpperCase()) {
+            case "ERROR":
+                holder.levelTextView.setTextColor(Color.RED);
+                break;
+            case "SUCCESS":
+                holder.levelTextView.setTextColor(Color.parseColor("#006400")); // Dark Green
+                break;
+            case "INFO":
+                holder.levelTextView.setTextColor(Color.BLUE);
+                break;
+            default:
+                holder.levelTextView.setTextColor(Color.BLACK);
+                break;
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        return logEntries != null ? logEntries.size() : 0;
+    }
+
+    public void updateLogEntries(List<LogEntry> newLogEntries) {
+        this.logEntries = newLogEntries;
+        notifyDataSetChanged(); // Consider using DiffUtil for more complex scenarios
+    }
+
+    static class LogViewHolder extends RecyclerView.ViewHolder {
+        TextView timestampTextView;
+        TextView levelTextView;
+        TextView messageTextView;
+        TextView detailTextView;
+
+        LogViewHolder(View itemView) {
+            super(itemView);
+            timestampTextView = itemView.findViewById(R.id.log_timestamp);
+            levelTextView = itemView.findViewById(R.id.log_level);
+            messageTextView = itemView.findViewById(R.id.log_message);
+            detailTextView = itemView.findViewById(R.id.log_detail);
+        }
+    }
+}

--- a/app/src/main/java/com/drgraff/speakkey/utils/LogEntry.java
+++ b/app/src/main/java/com/drgraff/speakkey/utils/LogEntry.java
@@ -1,0 +1,24 @@
+package com.drgraff.speakkey.utils;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+public class LogEntry {
+    public final long timestamp;
+    public final String level; // e.g., "INFO", "ERROR", "SUCCESS"
+    public final String message;
+    public final String detail;
+
+    public LogEntry(long timestamp, String level, String message, String detail) {
+        this.timestamp = timestamp;
+        this.level = level;
+        this.message = message;
+        this.detail = detail;
+    }
+
+    public String getFormattedTimestamp() {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.getDefault());
+        return sdf.format(new Date(timestamp));
+    }
+}

--- a/app/src/main/res/layout/activity_log.xml
+++ b/app/src/main/res/layout/activity_log.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".settings.LogActivity"> <!-- Temporary context, will be .utils.LogActivity or similar -->
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/log_recycler_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginBottom="8dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/clear_log_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:listitem="@layout/list_item_log" /> <!-- This references the next layout to be created -->
+
+    <Button
+        android:id="@+id/clear_log_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Clear Log"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginBottom="16dp"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/list_item_log.xml
+++ b/app/src/main/res/layout/list_item_log.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/log_timestamp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="12sp"
+            android:textStyle="italic"
+            android:layout_marginEnd="8dp"
+            android:text="2023-01-01 12:00:00"/>
+
+        <TextView
+            android:id="@+id/log_level"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="12sp"
+            android:textStyle="bold"
+            android:text="INFO"/>
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/log_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="14sp"
+        android:layout_marginTop="4dp"
+        android:text="Log message here"/>
+
+    <TextView
+        android:id="@+id/log_detail"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="13sp"
+        android:layout_marginTop="2dp"
+        android:textColor="@android:color/darker_gray"
+        android:textIsSelectable="true" 
+        android:text="Detail message here (e.g., exception details)"/>
+
+</LinearLayout>

--- a/app/src/main/res/menu/menu_drawer.xml
+++ b/app/src/main/res/menu/menu_drawer.xml
@@ -12,5 +12,9 @@
             android:id="@+id/nav_settings"
             android:icon="@drawable/ic_menu_settings"
             android:title="@string/nav_menu_settings" />
+        <item
+            android:id="@+id/nav_view_logs"
+            android:icon="@android:drawable/ic_menu_view"
+            android:title="View Logs" />
     </group>
 </menu>


### PR DESCRIPTION
This commit introduces an in-app logging feature to help diagnose API communication issues, particularly for Whisper and ChatGPT functionalities.

Key changes include:

1.  **Log Data Structures (`LogEntry.java`, `AppLogManager.java`):**
    *   `LogEntry`: Defines the structure for individual log messages (timestamp, level, message, detail).
    *   `AppLogManager`: A singleton to manage an in-memory list of log entries, providing methods to add, retrieve, and clear logs.

2.  **Integration with API Calls (`MainActivity.java`):**
    *   Logging calls (INFO, SUCCESS, ERROR) added to `transcribeAudio()` (Whisper) and `sendToChatGpt()` (ChatGPT) methods in `MainActivity` to record call attempts, successes (with response length), and failures (with exception details).

3.  **Log Display UI (`activity_log.xml`, `list_item_log.xml`, `LogAdapter.java`, `LogActivity.java`):**
    *   `activity_log.xml`: Layout for the log display screen, including a RecyclerView and a "Clear Log" button.
    *   `list_item_log.xml`: Layout for individual log entry rows.
    *   `LogAdapter.java`: RecyclerView.Adapter to bind log data to the UI, with color-coding for log levels.
    *   `LogActivity.java`: Activity to display the logs, manage log clearing, and provide "Up" navigation.

4.  **Navigation Drawer Integration:**
    *   "View Logs" option added to the navigation drawer menu.
    *   `MainActivity` updated to launch `LogActivity`.
    *   `LogActivity` declared in `AndroidManifest.xml`.

This logging feature will be used to further investigate and resolve the Whisper transcription failures.