### PR TITLE
Fix: Correct Whisper API URL handling to prevent "Invalid URL" error.

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/api/WhisperApi.java
+++ b/app/src/main/java/com/drgraff/speakkey/api/WhisperApi.java
@@ -32,7 +32,16 @@ public class WhisperApi {
      */
     public WhisperApi(String apiKey, String endpoint, String language) {
         this.apiKey = apiKey;
-        this.endpoint = endpoint;
+        
+        String correctedEndpoint = endpoint;
+        if (correctedEndpoint != null) {
+            // Remove trailing slashes
+            while (correctedEndpoint.endsWith("/")) {
+                correctedEndpoint = correctedEndpoint.substring(0, correctedEndpoint.length() - 1);
+            }
+        }
+        this.endpoint = correctedEndpoint;
+        
         this.language = language;
     }
     


### PR DESCRIPTION
Addresses an "Invalid URL (POST /v1/audio/transcriptions/)" error during Whisper API calls. The error was caused by a trailing slash in the request URL.

Changes:
1.  I verified that the default Whisper endpoint URL in `MainActivity.java` is correct and does not contain a trailing slash.
2.  I modified the `WhisperApi.java` constructor to defensively remove any trailing slashes from the `endpoint` string parameter before it's used as the Retrofit `baseUrl`. This ensures robustness if the URL is misconfigured with a trailing slash in your settings.

These changes ensure the final URL used for the Whisper API call is correctly formatted, resolving the reported transcription failure.