### PR TITLE
Fix: Correct Retrofit baseUrl and endpoint path for Whisper API.

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -155,7 +155,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     private void initializeApis() {
         String apiKey = sharedPreferences.getString("openai_api_key", "");
         String whisperEndpoint = sharedPreferences.getString("whisper_endpoint", 
-                "https://api.openai.com/v1/audio/transcriptions");
+                "https://api.openai.com/"); // Ensure this ends with a slash
         String model = sharedPreferences.getString("chatgpt_model", "gpt-3.5-turbo");
         String language = sharedPreferences.getString("language", "en");
         

--- a/app/src/main/java/com/drgraff/speakkey/api/WhisperApi.java
+++ b/app/src/main/java/com/drgraff/speakkey/api/WhisperApi.java
@@ -34,11 +34,18 @@ public class WhisperApi {
         this.apiKey = apiKey;
         
         String correctedEndpoint = endpoint;
-        if (correctedEndpoint != null) {
-            // Remove trailing slashes
+        if (correctedEndpoint != null && !correctedEndpoint.trim().isEmpty()) { // Check for non-empty after trimming whitespace
+            // Remove all existing trailing slashes first to handle cases like "http://example.com///"
             while (correctedEndpoint.endsWith("/")) {
                 correctedEndpoint = correctedEndpoint.substring(0, correctedEndpoint.length() - 1);
             }
+            // Then add a single trailing slash
+            correctedEndpoint += "/";
+        } else {
+            // If endpoint is null, empty, or whitespace-only, this is problematic.
+            // Throw an error or use a hardcoded default known to be correct.
+            // Given MainActivity provides a default, an exception for a bad configured state is reasonable.
+            throw new IllegalArgumentException("Endpoint URL cannot be null or empty.");
         }
         this.endpoint = correctedEndpoint;
         

--- a/app/src/main/java/com/drgraff/speakkey/api/WhisperApiService.java
+++ b/app/src/main/java/com/drgraff/speakkey/api/WhisperApiService.java
@@ -23,7 +23,7 @@ public interface WhisperApiService {
      * @return Response containing the transcription
      */
     @Multipart
-    @POST(".")
+    @POST("v1/audio/transcriptions")
     Call<WhisperApiResponse> transcribeAudio(
         @Header("Authorization") String authorization,
         @Part MultipartBody.Part file,


### PR DESCRIPTION
Resolves "IllegalArgumentException: baseUrl must end in /" and a previous "Invalid URL (POST /v1/audio/transcriptions/)" error during Whisper API calls.

The changes ensure Retrofit is configured correctly:
1.  `WhisperApiService.java`: Changed `@POST(".")` to `@POST("v1/audio/transcriptions")` to define the specific API path.
2.  `WhisperApi.java`: The constructor now expects the base API URL (e.g., "https://api.openai.com/"). It ensures this URL string ends with exactly one trailing slash before being used as Retrofit's `baseUrl`.
3.  `MainActivity.java`: Updated the default value for the `whisper_endpoint` preference to be the base API URL ("https://api.openai.com/").

This ensures that Retrofit's `baseUrl` requirement (must end in a slash) is met, and the final resolved URL for the API call is correctly formed as "https://api.openai.com/v1/audio/transcriptions".