### PR TITLE
Fix: Simplify Whisper API endpoint handling for correct URL resolution.

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -155,7 +155,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     private void initializeApis() {
         String apiKey = sharedPreferences.getString("openai_api_key", "");
         String whisperEndpoint = sharedPreferences.getString("whisper_endpoint", 
-                "https://api.openai.com/"); // Ensure this ends with a slash
+                "https://api.openai.com"); // No trailing slash
         String model = sharedPreferences.getString("chatgpt_model", "gpt-3.5-turbo");
         String language = sharedPreferences.getString("language", "en");
         

--- a/app/src/main/java/com/drgraff/speakkey/api/WhisperApi.java
+++ b/app/src/main/java/com/drgraff/speakkey/api/WhisperApi.java
@@ -3,6 +3,7 @@ package com.drgraff.speakkey.api;
 import android.util.Log;
 
 import java.io.File;
+// Unused imports for URL and MalformedURLException will be removed by not re-adding them.
 
 import okhttp3.MediaType;
 import okhttp3.MultipartBody;
@@ -32,24 +33,12 @@ public class WhisperApi {
      */
     public WhisperApi(String apiKey, String endpoint, String language) {
         this.apiKey = apiKey;
-        
-        String correctedEndpoint = endpoint;
-        if (correctedEndpoint != null && !correctedEndpoint.trim().isEmpty()) { // Check for non-empty after trimming whitespace
-            // Remove all existing trailing slashes first to handle cases like "http://example.com///"
-            while (correctedEndpoint.endsWith("/")) {
-                correctedEndpoint = correctedEndpoint.substring(0, correctedEndpoint.length() - 1);
-            }
-            // Then add a single trailing slash
-            correctedEndpoint += "/";
-        } else {
-            // If endpoint is null, empty, or whitespace-only, this is problematic.
-            // Throw an error or use a hardcoded default known to be correct.
-            // Given MainActivity provides a default, an exception for a bad configured state is reasonable.
-            throw new IllegalArgumentException("Endpoint URL cannot be null or empty.");
-        }
-        this.endpoint = correctedEndpoint;
-        
         this.language = language;
+
+        if (endpoint == null || endpoint.trim().isEmpty()) {
+            throw new IllegalArgumentException("Endpoint URL cannot be null, empty, or whitespace-only.");
+        }
+        this.endpoint = endpoint.trim(); // Assign trimmed endpoint directly
     }
     
     /**

--- a/app/src/main/java/com/drgraff/speakkey/api/WhisperApiService.java
+++ b/app/src/main/java/com/drgraff/speakkey/api/WhisperApiService.java
@@ -23,7 +23,7 @@ public interface WhisperApiService {
      * @return Response containing the transcription
      */
     @Multipart
-    @POST("v1/audio/transcriptions")
+    @POST("/v1/audio/transcriptions") // Added leading slash
     Call<WhisperApiResponse> transcribeAudio(
         @Header("Authorization") String authorization,
         @Part MultipartBody.Part file,


### PR DESCRIPTION
This commit resolves persistent issues with Whisper API URL formation, based on your feedback and successful experimental configuration. The previous "Invalid URL (POST ...)" errors, including path duplication or "baseUrl must end in /", should now be fixed.

Changes:
1.  `WhisperApiService.java`: Verified that the `@POST` annotation path for `transcribeAudio` is `"/v1/audio/transcriptions"` (with a leading slash, making it absolute relative to the base URL).
2.  `WhisperApi.java`: The constructor has been significantly simplified. It now takes the `endpoint` string, trims it, checks for null/emptiness, and uses it directly as Retrofit's `baseUrl`. All previous complex URL parsing and manual slash manipulation logic has been removed.
3.  `MainActivity.java`: The default value for the `whisper_endpoint` preference has been updated to `"https://api.openai.com"` (no trailing slash). This aligns with the user-confirmed working configuration.

This approach relies on Retrofit's standard behavior for combining a `baseUrl` (which can be `scheme://host` or `scheme://host/`) with an absolute path defined in the service interface's HTTP method annotation. It simplifies the endpoint configuration and should lead to consistent and correct URL resolution for the Whisper API.