### PR TITLE
Fix: Enable scrolling for Whisper and ChatGPT text boxes.

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -101,6 +101,9 @@
         android:padding="8dp"
         android:gravity="top|start"
         android:inputType="textMultiLine"
+        android:scrollbars="vertical"
+        android:minLines="3"
+        android:maxLines="100"
         app:layout_constraintTop_toBottomOf="@id/whisper_label"
         app:layout_constraintBottom_toTopOf="@id/whisper_controls"
         app:layout_constraintHeight_percent="0.2" />
@@ -164,6 +167,9 @@
         android:padding="8dp"
         android:gravity="top|start"
         android:inputType="textMultiLine"
+        android:scrollbars="vertical"
+        android:minLines="3"
+        android:maxLines="100"
         app:layout_constraintTop_toBottomOf="@id/chatgpt_label"
         app:layout_constraintBottom_toTopOf="@id/chatgpt_controls"
         app:layout_constraintHeight_percent="0.2" />


### PR DESCRIPTION
Modifies the EditText views for Whisper transcription (`whisper_text`) and ChatGPT response (`chatgpt_text`) in `content_main.xml` to make them vertically scrollable.

Changes include adding the following attributes to both EditTexts:
- android:scrollbars="vertical" (to make scrollbars visible)
- android:minLines="3" (to provide a reasonable default size)
- android:maxLines="100" (to allow for ample text and enable scrolling)

This addresses the issue where long transcriptions or responses were not fully visible or editable.