### PR TITLE
Fix: Improve EditText scrolling in portrait mode.

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -93,7 +93,7 @@
     <EditText
         android:id="@+id/whisper_text"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_height="120dp"
         android:layout_marginTop="8dp"
         android:layout_marginBottom="8dp"
         android:background="@color/edit_text_background"
@@ -107,8 +107,7 @@
         android:minLines="3"
         android:maxLines="100"
         app:layout_constraintTop_toBottomOf="@id/whisper_label"
-        app:layout_constraintBottom_toTopOf="@id/whisper_controls"
-        app:layout_constraintHeight_percent="0.2" />
+        app:layout_constraintBottom_toTopOf="@id/whisper_controls" />
 
     <LinearLayout
         android:id="@+id/whisper_controls"
@@ -161,7 +160,7 @@
     <EditText
         android:id="@+id/chatgpt_text"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_height="120dp"
         android:layout_marginTop="8dp"
         android:layout_marginBottom="8dp"
         android:background="@color/edit_text_background"
@@ -175,8 +174,7 @@
         android:minLines="3"
         android:maxLines="100"
         app:layout_constraintTop_toBottomOf="@id/chatgpt_label"
-        app:layout_constraintBottom_toTopOf="@id/chatgpt_controls"
-        app:layout_constraintHeight_percent="0.2" />
+        app:layout_constraintBottom_toTopOf="@id/chatgpt_controls" />
 
     <LinearLayout
         android:id="@+id/chatgpt_controls"


### PR DESCRIPTION
Changes the layout_height of the Whisper and ChatGPT EditText views in `content_main.xml` from a percentage-based height to a fixed height of 120dp.

This aims to resolve an issue where direct touch scrolling on the EditTexts was not working reliably in portrait mode, even though it worked in landscape (possibly due to IME interactions). Providing a fixed, predictable height for these views should help their internal scrolling mechanisms (with nestedScrollingEnabled=true) function more consistently across orientations when their content exceeds their visible bounds.