### PR TITLE
Refactor: Adjust UI layout and add Auto-Send to ChatGPT feature.

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -60,7 +60,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     private EditText whisperText, chatGptText;
     private View recordingIndicator;
     private TextView recordingTime;
-    private CheckBox chkAutoSendWhisper, chkAutoSendInputStick;
+    private CheckBox chkAutoSendWhisper, chkAutoSendInputStick, chkAutoSendToChatGpt; // Added chkAutoSendToChatGpt
 
     // Audio recording
     private MediaRecorder mediaRecorder;
@@ -148,6 +148,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         // Recording indicator
         recordingIndicator = findViewById(R.id.recording_indicator);
         recordingTime = findViewById(R.id.recording_time);
+
+        // ChatGPT section (added checkbox)
+        chkAutoSendToChatGpt = findViewById(R.id.chk_auto_send_to_chatgpt);
         
         // Set up click listeners
         setupClickListeners();
@@ -155,6 +158,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         // Set initial checkbox states from preferences
         chkAutoSendWhisper.setChecked(sharedPreferences.getBoolean("auto_send_whisper", true));
         chkAutoSendInputStick.setChecked(sharedPreferences.getBoolean("auto_send_inputstick", false));
+        chkAutoSendToChatGpt.setChecked(sharedPreferences.getBoolean("auto_send_to_chatgpt", false));
 
         // Listener to improve EditText scrolling within ScrollView
         View.OnTouchListener editTextTouchListener = (v, event) -> {
@@ -219,6 +223,10 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         
         chkAutoSendInputStick.setOnCheckedChangeListener((buttonView, isChecked) -> {
             sharedPreferences.edit().putBoolean("auto_send_inputstick", isChecked).apply();
+        });
+        
+        chkAutoSendToChatGpt.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            sharedPreferences.edit().putBoolean("auto_send_to_chatgpt", isChecked).apply();
         });
     }
     
@@ -415,6 +423,13 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                 mainHandler.post(() -> {
                     whisperText.setText(transcription);
                     Toast.makeText(MainActivity.this, "Transcription complete", Toast.LENGTH_SHORT).show();
+
+                    // Add this:
+                    if (chkAutoSendToChatGpt.isChecked()) {
+                        // Log this action
+                        AppLogManager.getInstance().addEntry("INFO", "Auto-sending transcript to ChatGPT...", null);
+                        sendToChatGpt(); // Call sendToChatGpt automatically
+                    }
                 });
             } catch (Exception e) {
                 Log.e(TAG, "Error transcribing audio", e);
@@ -572,6 +587,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         initializeApis();
         chkAutoSendWhisper.setChecked(sharedPreferences.getBoolean("auto_send_whisper", true));
         chkAutoSendInputStick.setChecked(sharedPreferences.getBoolean("auto_send_inputstick", false));
+        chkAutoSendToChatGpt.setChecked(sharedPreferences.getBoolean("auto_send_to_chatgpt", false));
     }
     
     @Override

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -19,35 +19,36 @@
         android:id="@+id/recording_controls"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:gravity="center"
+        android:orientation="horizontal"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
 
         <Button
             android:id="@+id/btn_start_recording"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/start_recording"
             android:layout_margin="4dp" />
 
         <Button
             android:id="@+id/btn_pause_recording"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/pause_recording"
             android:enabled="false"
             android:layout_margin="4dp" />
 
         <Button
             android:id="@+id/btn_stop_recording"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/stop_recording"
             android:enabled="false"
             android:layout_margin="4dp" />
-
     </LinearLayout>
 
     <!-- Recording Indicator -->
@@ -114,36 +115,51 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:gravity="center"
+        android:gravity="center_horizontal" <!-- Center the rows if they are wrap_content -->
         app:layout_constraintTop_toBottomOf="@id/whisper_text">
 
-        <CheckBox
-            android:id="@+id/chk_auto_send_whisper"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="wrap_content" 
             android:layout_height="wrap_content"
-            android:text="Auto-send"
-            android:layout_margin="4dp" />
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
 
-        <Button
-            android:id="@+id/btn_send_whisper"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/send_to_whisper"
-            android:layout_margin="4dp" />
+            <Button
+                android:id="@+id/btn_send_whisper"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/send_to_whisper"
+                android:layout_marginEnd="8dp"/> <!-- Adjust margin as needed -->
 
-        <Button
-            android:id="@+id/btn_clear_recording"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/clear_recording"
-            android:layout_margin="4dp" />
+            <CheckBox
+                android:id="@+id/chk_auto_send_whisper"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Auto-send"/> 
+        </LinearLayout>
 
-        <Button
-            android:id="@+id/btn_clear_transcription"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/clear_transcription"
-            android:layout_margin="4dp" />
+            android:orientation="horizontal"
+            android:layout_marginTop="8dp"> <!-- Add some top margin -->
+
+            <Button
+                android:id="@+id/btn_clear_recording"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/clear_recording"
+                android:layout_marginEnd="4dp"/> <!-- Small margin between buttons -->
+
+            <Button
+                android:id="@+id/btn_clear_transcription"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/clear_transcription"
+                android:layout_marginStart="4dp"/> <!-- Small margin between buttons -->
+        </LinearLayout>
     </LinearLayout>
 
     <!-- ChatGPT Section -->
@@ -180,23 +196,36 @@
         android:id="@+id/chatgpt_controls"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:gravity="center"
+        android:orientation="vertical" 
+        android:gravity="center_horizontal" 
         app:layout_constraintTop_toBottomOf="@id/chatgpt_text">
 
-        <Button
-            android:id="@+id/btn_send_chatgpt"
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/send_to_chatgpt"
-            android:layout_margin="4dp" />
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <Button
+                android:id="@+id/btn_send_chatgpt"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/send_to_chatgpt"
+                android:layout_marginEnd="8dp"/> <!-- Adjust margin -->
+
+            <CheckBox
+                android:id="@+id/chk_auto_send_to_chatgpt"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Auto Send to ChatGPT"/> 
+        </LinearLayout>
 
         <Button
             android:id="@+id/btn_clear_chatgpt"
-            android:layout_width="wrap_content"
+            android:layout_width="wrap_content" 
             android:layout_height="wrap_content"
             android:text="@string/clear_chatgpt_response"
-            android:layout_margin="4dp" />
+            android:layout_marginTop="8dp"/> <!-- Add margin -->
     </LinearLayout>
 
     <!-- InputStick Section -->
@@ -210,19 +239,19 @@
         app:layout_constraintTop_toBottomOf="@id/chatgpt_controls"
         app:layout_constraintBottom_toBottomOf="parent">
 
-        <CheckBox
-            android:id="@+id/chk_auto_send_inputstick"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Auto-send"
-            android:layout_margin="4dp" />
-
         <Button
             android:id="@+id/btn_send_inputstick"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/send_to_inputstick"
-            android:layout_margin="4dp" />
+            android:layout_marginEnd="8dp"/> <!-- Added marginEnd for spacing -->
+
+        <CheckBox
+            android:id="@+id/chk_auto_send_inputstick"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Auto-send" /> 
+            <!-- Removed original layout_margin, relying on button's marginEnd -->
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This commit implements several UI layout adjustments in content_main.xml as per your request, and introduces a new "Auto Send to ChatGPT" functionality.

Layout Changes (`content_main.xml`):
- Recording Buttons: "Start", "Pause", "Stop" buttons are now on a single line, distributed equally.
- Whisper Controls:
    - "Send to Whisper" button and "Auto Send" checkbox are on one line.
    - "Clear Recording" and "Clear Transcription" buttons are on a separate line, distributed equally.
- ChatGPT Controls:
    - A new "Auto Send to ChatGPT" checkbox is added.
    - "Send to ChatGPT" button and this new checkbox are on one line.
    - "Clear ChatGPT Response" button is on the line below.
- InputStick Controls: "Send to InputStick" button is now to the left of its "Auto-send" checkbox on the same line.

New Functionality (`MainActivity.java`):
- Added `chk_auto_send_to_chatgpt` CheckBox.
- Its state is persisted in SharedPreferences.
- If checked, after a Whisper transcription is successfully completed, the transcribed text is automatically sent to ChatGPT.