### PR TITLE
Fix: Correct XML syntax error in content_main.xml.

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -115,7 +115,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:gravity="center_horizontal" <!-- Center the rows if they are wrap_content -->
+        android:gravity="center_horizontal"
         app:layout_constraintTop_toBottomOf="@id/whisper_text">
 
         <LinearLayout


### PR DESCRIPTION
Resolves a SAXParseException that caused build failures. The error was due to an XML comment being improperly placed inside the opening tag of a LinearLayout (id: whisper_controls) after an attribute definition.

The invalid comment has been removed, restoring correct XML syntax.