### PR TITLE
Update UI text and layout heights

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -94,7 +94,7 @@
     <EditText
         android:id="@+id/whisper_text"
         android:layout_width="match_parent"
-        android:layout_height="120dp"
+        android:layout_height="180dp"
         android:layout_marginTop="8dp"
         android:layout_marginBottom="8dp"
         android:background="@color/edit_text_background"
@@ -176,7 +176,7 @@
     <EditText
         android:id="@+id/chatgpt_text"
         android:layout_width="match_parent"
-        android:layout_height="120dp"
+        android:layout_height="180dp"
         android:layout_marginTop="8dp"
         android:layout_marginBottom="8dp"
         android:background="@color/edit_text_background"
@@ -217,7 +217,7 @@
                 android:id="@+id/chk_auto_send_to_chatgpt"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Auto Send to ChatGPT"/> 
+                android:text="Auto-send"/> 
         </LinearLayout>
 
         <Button

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,12 +4,12 @@
     <string name="action_settings">Settings</string>
     
     <!-- Main UI -->
-    <string name="start_recording">Start Recording</string>
-    <string name="pause_recording">Pause Recording</string>
-    <string name="stop_recording">Stop Recording</string>
+    <string name="start_recording">Start Record</string>
+    <string name="pause_recording">Pause Record</string>
+    <string name="stop_recording">Stop Record</string>
     <string name="send_to_whisper">Send to Whisper</string>
     <string name="clear_recording">Clear Recording</string>
-    <string name="clear_transcription">Clear Transcription</string>
+    <string name="clear_transcription">Clear Transcript</string>
     <string name="send_to_chatgpt">Send to ChatGPT</string>
     <string name="clear_chatgpt_response">Clear Response</string>
     <string name="send_to_inputstick">Send to InputStick</string>


### PR DESCRIPTION
This commit includes the following changes:

- Button text updates:
    - "Start Recording" to "Start Record"
    - "Pause Recording" to "Pause Record"
    - "Stop Recording" to "Stop Record"
    - "Clear Transcription" to "Clear Transcript"
- CheckBox text update:
    - "Auto Send to ChatGPT" to "Auto-send"
- EditText height increase:
    - Increased height of Whisper and ChatGPT text boxes from 120dp to 180dp.