### PR TITLE
I've simplified the InputStick integration using a broadcast method.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     implementation 'androidx.media:media:1.6.0'
 
     // InputStick API (local module)
-    implementation project(':inputstickapi')
+    // implementation project(':inputstickapi')
     
     // Testing libraries
     testImplementation 'junit:junit:4.13.2'

--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -32,7 +32,8 @@ import com.drgraff.speakkey.api.ChatGptApi;
 import com.drgraff.speakkey.api.WhisperApi;
 import com.drgraff.speakkey.data.Prompt;
 import com.drgraff.speakkey.data.PromptManager;
-import com.drgraff.speakkey.inputstick.InputStickManager;
+import com.drgraff.speakkey.inputstick.InputStickBroadcast; // Added
+// import com.drgraff.speakkey.inputstick.InputStickManager; // Removed
 import com.drgraff.speakkey.settings.SettingsActivity;
 import com.drgraff.speakkey.utils.AppLogManager;
 import com.drgraff.speakkey.utils.ThemeManager;
@@ -74,7 +75,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     // APIs
     private WhisperApi whisperApi;
     private ChatGptApi chatGptApi;
-    private InputStickManager inputStickManager;
+    // private InputStickManager inputStickManager; // Removed
     
     // Settings
     private SharedPreferences sharedPreferences;
@@ -214,7 +215,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         
         whisperApi = new WhisperApi(apiKey, whisperEndpoint, language);
         chatGptApi = new ChatGptApi(apiKey, model);
-        inputStickManager = new InputStickManager(this);
+        // inputStickManager = new InputStickManager(this); // Removed
     }
     
     private void setupClickListeners() {
@@ -552,22 +553,21 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         
         String text = chatGptText.getText().toString();
         if (text.isEmpty()) {
-            Toast.makeText(this, "No text to send", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, "No text to send to InputStick", Toast.LENGTH_SHORT).show(); // Clarified message
             return;
         }
-        
-        inputStickManager.connect(connected -> {
-            if (connected) {
-                inputStickManager.typeText(text);
-                mainHandler.post(() -> {
-                    Toast.makeText(MainActivity.this, "Text sent to InputStick", Toast.LENGTH_SHORT).show();
-                });
-            } else {
-                mainHandler.post(() -> {
-                    Toast.makeText(MainActivity.this, R.string.error_inputstick, Toast.LENGTH_SHORT).show();
-                });
-            }
-        });
+
+        // Check if InputStickUtility is installed and supported
+        if (com.drgraff.speakkey.inputstick.InputStickBroadcast.isSupported(this, true)) {
+            // Send the text using InputStickBroadcast
+            com.drgraff.speakkey.inputstick.InputStickBroadcast.type(this, text, "en-US"); // Using "en-US" as default layout
+            Toast.makeText(MainActivity.this, "Text sent via InputStick broadcast", Toast.LENGTH_SHORT).show();
+            AppLogManager.getInstance().addEntry("INFO", "InputStick: Text broadcasted", "Length: " + text.length());
+        } else {
+            // isSupported() already shows a dialog if not installed/updated.
+            // Optionally, add another toast or log if needed, but DownloadDialog should handle user notification.
+            AppLogManager.getInstance().addEntry("WARN", "InputStick: Utility not supported or user cancelled download.", null);
+        }
     }
     
     @Override

--- a/app/src/main/java/com/drgraff/speakkey/inputstick/DownloadDialog.java
+++ b/app/src/main/java/com/drgraff/speakkey/inputstick/DownloadDialog.java
@@ -1,0 +1,47 @@
+package com.drgraff.speakkey.inputstick; // Corrected package
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.net.Uri;
+
+public class DownloadDialog {
+
+        public static final int NOT_INSTALLED = 0;
+        public static final int NOT_UPDATED = 1;
+
+        public static AlertDialog getDialog(final Context ctx, final int messageCode) {
+                AlertDialog.Builder downloadDialog = new AlertDialog.Builder(ctx);
+
+                if (messageCode == NOT_UPDATED) {
+                        downloadDialog.setTitle("InputStickUtility app must be updated");
+                        downloadDialog.setMessage("It appears that you are using older version of InputStickUtility application. Update now (GoolePlay)?");
+                } else {
+                        downloadDialog.setTitle("InputStickUtility app NOT installed");
+                        downloadDialog.setMessage("InputStickUtility is required to complete this action. Download now (GoolePlay)?\nNote: InputStick USB receiver (HARDWARE!) is also required.");
+                }
+                downloadDialog.setPositiveButton("Yes",
+                                new DialogInterface.OnClickListener() {
+                                        @Override
+                                        public void onClick(DialogInterface dialogInterface, int i) {
+                                                final String appPackageName = "com.inputstick.apps.inputstickutility";
+                                                try {
+                                                        ctx.startActivity(new Intent(Intent.ACTION_VIEW,
+                                                                        Uri.parse("market://details?id=" + appPackageName)));
+                                                } catch (android.content.ActivityNotFoundException anfe) {
+                                                        ctx.startActivity(new Intent(
+                                                                        Intent.ACTION_VIEW,
+                                                                        Uri.parse("http://play.google.com/store/apps/details?id=" + appPackageName)));
+                                                }
+                                        }
+                                });
+                downloadDialog.setNegativeButton("No",
+                                new DialogInterface.OnClickListener() {
+                                        @Override
+                                        public void onClick(DialogInterface dialogInterface, int i) {
+                                        }
+                                });
+                return downloadDialog.show();
+        }
+}

--- a/app/src/main/java/com/drgraff/speakkey/inputstick/HIDKeycodes.java
+++ b/app/src/main/java/com/drgraff/speakkey/inputstick/HIDKeycodes.java
@@ -1,0 +1,300 @@
+package com.drgraff.speakkey.inputstick; // Corrected package
+
+import android.util.SparseArray;
+
+public class HIDKeycodes {
+
+        public static final byte NONE =                                 0x00;
+
+        public static final byte CTRL_LEFT =                    0x01;
+        public static final byte SHIFT_LEFT =                   0x02;
+        public static final byte ALT_LEFT =                     0x04;
+        public static final byte GUI_LEFT =                     0x08;
+        public static final byte CTRL_RIGHT =                   0x10;
+        public static final byte SHIFT_RIGHT =                  0x20;
+        public static final byte ALT_RIGHT =                    0x40;
+        public static final byte GUI_RIGHT =      (byte)0x80;
+
+        public static final byte KEY_ENTER =                    0x28;
+        public static final byte KEY_ESCAPE =                   0x29;
+        public static final byte KEY_BACKSPACE =                0x2A;
+        public static final byte KEY_TAB =                              0x2B;
+        public static final byte KEY_SPACEBAR =                 0x2C;
+
+        public static final byte KEY_CAPS_LOCK =                0x39;
+
+        public static final byte KEY_1 =                                0x1E;
+        public static final byte KEY_2 =                                0x1F;
+        public static final byte KEY_3 =                                0x20;
+        public static final byte KEY_4 =                                0x21;
+        public static final byte KEY_5 =                                0x22;
+        public static final byte KEY_6 =                                0x23;
+        public static final byte KEY_7 =                                0x24;
+        public static final byte KEY_8 =                                0x25;
+        public static final byte KEY_9 =                                0x26;
+        public static final byte KEY_0 =                                0x27;
+
+        public static final byte KEY_F1 =                               0x3A;
+        public static final byte KEY_F2 =                               0x3B;
+        public static final byte KEY_F3 =                               0x3C;
+        public static final byte KEY_F4 =                               0x3D;
+        public static final byte KEY_F5 =                               0x3E;
+        public static final byte KEY_F6 =                               0x3F;
+        public static final byte KEY_F7 =                               0x40;
+        public static final byte KEY_F8 =                               0x41;
+        public static final byte KEY_F9 =                               0x42;
+        public static final byte KEY_F10 =                              0x43;
+        public static final byte KEY_F11 =                              0x44;
+        public static final byte KEY_F12 =                              0x45;
+
+        public static final byte KEY_PRINT_SCREEN =     0x46;
+        public static final byte KEY_SCROLL_LOCK =              0x47;
+        public static final byte KEY_PASUE =                    0x48; // Note: Original might have typo "PASUE" vs "PAUSE"
+        public static final byte KEY_INSERT =                   0x49;
+        public static final byte KEY_HOME =                     0x4A;
+        public static final byte KEY_PAGE_UP =                  0x4B;
+        public static final byte KEY_DELETE =                   0x4C;
+        public static final byte KEY_END =                              0x4D;
+        public static final byte KEY_PAGE_DOWN =                0x4E;
+
+        public static final byte KEY_ARROW_RIGHT =              0x4F;
+        public static final byte KEY_ARROW_LEFT =               0x50;
+        public static final byte KEY_ARROW_DOWN =               0x51;
+        public static final byte KEY_ARROW_UP =                 0x52;
+
+        public static final byte KEY_NUM_LOCK =                 0x53;
+        public static final byte KEY_NUM_SLASH =                0x54;
+        public static final byte KEY_NUM_STAR =                 0x55;
+        public static final byte KEY_NUM_MINUS =                0x56;
+        public static final byte KEY_NUM_PLUS =                 0x57;
+        public static final byte KEY_NUM_ENTER =                0x58;
+        public static final byte KEY_NUM_1 =                    0x59;
+        public static final byte KEY_NUM_2 =                    0x5A;
+        public static final byte KEY_NUM_3 =                    0x5B;
+        public static final byte KEY_NUM_4 =                    0x5C;
+        public static final byte KEY_NUM_5 =                    0x5D;
+        public static final byte KEY_NUM_6 =                    0x5E;
+        public static final byte KEY_NUM_7 =                    0x5F;
+        public static final byte KEY_NUM_8 =                    0x60;
+        public static final byte KEY_NUM_9 =                    0x61;
+        public static final byte KEY_NUM_0 =                    0x62;
+        public static final byte KEY_NUM_DOT =                  0x63;
+
+        public static final byte KEY_BACKSLASH_NON_US = 0x64;
+
+        public static final byte KEY_A =                                0x04;
+        public static final byte KEY_B =                                0x05;
+        public static final byte KEY_C =                                0x06;
+        public static final byte KEY_D =                                0x07;
+        public static final byte KEY_E =                                0x08;
+        public static final byte KEY_F =                                0x09;
+        public static final byte KEY_G =                                0x0A;
+        public static final byte KEY_H =                                0x0B;
+        public static final byte KEY_I =                                0x0C;
+        public static final byte KEY_J =                                0x0D;
+        public static final byte KEY_K =                                0x0E;
+        public static final byte KEY_L =                                0x0F;
+        public static final byte KEY_M =                                0x10;
+        public static final byte KEY_N =                                0x11;
+        public static final byte KEY_O =                                0x12;
+        public static final byte KEY_P =                                0x13;
+        public static final byte KEY_Q =                                0x14;
+        public static final byte KEY_R =                                0x15;
+        public static final byte KEY_S =                                0x16;
+        public static final byte KEY_T =                                0x17;
+        public static final byte KEY_U =                                0x18;
+        public static final byte KEY_V =                                0x19;
+        public static final byte KEY_W =                                0x1A;
+        public static final byte KEY_X =                                0x1B;
+        public static final byte KEY_Y =                                0x1C;
+        public static final byte KEY_Z =                                0x1D;
+
+        public static final byte KEY_MINUS =                    0x2D;
+        public static final byte KEY_EQUALS =                   0x2E;
+        public static final byte KEY_LEFT_BRACKET =     0x2F;
+        public static final byte KEY_RIGHT_BRACKET =    0x30;
+        public static final byte KEY_BACKSLASH =                0x31;
+        public static final byte KEY_SEMICOLON =                0x33;
+        public static final byte KEY_APOSTROPHE =               0x34;
+        public static final byte KEY_GRAVE =                    0x35;
+        public static final byte KEY_COMA =                     0x36;
+        public static final byte KEY_DOT =                              0x37;
+        public static final byte KEY_SLASH =                    0x38;
+
+        public static final byte KEY_APPLICATION =              0x65;
+
+        public static final SparseArray<String> modifiersMap;
+        static {
+            modifiersMap = new SparseArray<String>();
+            modifiersMap.put(CTRL_LEFT, "Left Ctrl");
+            modifiersMap.put(SHIFT_LEFT, "Left Shift");
+            modifiersMap.put(ALT_LEFT, "Left Alt");
+            modifiersMap.put(GUI_LEFT, "Left GUI");
+            modifiersMap.put(CTRL_RIGHT, "Right Ctrl");
+            modifiersMap.put(SHIFT_RIGHT, "Right Shift");
+            modifiersMap.put(ALT_RIGHT, "Right Alt");
+            modifiersMap.put(GUI_RIGHT, "Right GUI");
+        }
+
+        public static final SparseArray<String> keyMap;
+        static {
+            keyMap = new SparseArray<String>();
+            keyMap.put(0,"None");
+            keyMap.put(KEY_ENTER,"Enter");
+            keyMap.put(KEY_ESCAPE ,"Esc");
+            keyMap.put(KEY_BACKSPACE  ,"Backspace");
+            keyMap.put(KEY_TAB  ,"Tab");
+            keyMap.put(KEY_SPACEBAR  ,"Space");
+            keyMap.put(KEY_CAPS_LOCK  ,"CapsLock");
+            keyMap.put(KEY_1  ,"1");
+            keyMap.put(KEY_2  ,"2");
+            keyMap.put(KEY_3  ,"3");
+            keyMap.put(KEY_4  ,"4");
+            keyMap.put(KEY_5  ,"5");
+            keyMap.put(KEY_6  ,"6");
+            keyMap.put(KEY_7  ,"7");
+            keyMap.put(KEY_8  ,"8");
+            keyMap.put(KEY_9  ,"9");
+            keyMap.put(KEY_0  ,"0");
+            keyMap.put(KEY_F1  ,"F1");
+            keyMap.put(KEY_F2  ,"F2");
+            keyMap.put(KEY_F3  ,"F3");
+            keyMap.put(KEY_F4  ,"F4");
+            keyMap.put(KEY_F5  ,"F5");
+            keyMap.put(KEY_F6  ,"F6");
+            keyMap.put(KEY_F7  ,"F7");
+            keyMap.put(KEY_F8  ,"F8");
+            keyMap.put(KEY_F9  ,"F9");
+            keyMap.put(KEY_F10  ,"F10");
+            keyMap.put(KEY_F11  ,"F11");
+            keyMap.put(KEY_F12  ,"F12");
+            keyMap.put(KEY_PRINT_SCREEN   ,"Print Scrn");
+            keyMap.put(KEY_SCROLL_LOCK   ,"ScrollLock");
+            keyMap.put(KEY_PASUE   ,"Pause Break"); // Typo "PASUE"
+            keyMap.put(KEY_INSERT   ,"Insert");
+            keyMap.put(KEY_HOME   ,"Home");
+            keyMap.put(KEY_PAGE_UP   ,"PageUp");
+            keyMap.put(KEY_DELETE   ,"Delete");
+            keyMap.put(KEY_END   ,"End");
+            keyMap.put(KEY_PAGE_DOWN   ,"PageDown");
+            keyMap.put(KEY_ARROW_RIGHT   ,"Right Arrow");
+            keyMap.put(KEY_ARROW_LEFT   ,"Left Arrow");
+            keyMap.put(KEY_ARROW_DOWN   ,"Down Arrow");
+            keyMap.put(KEY_ARROW_UP   ,"Up Arrow");
+            keyMap.put(KEY_NUM_LOCK   ,"NumLock");
+            keyMap.put(KEY_NUM_SLASH   ,"Num /");
+            keyMap.put(KEY_NUM_STAR   ,"Num *");
+            keyMap.put(KEY_NUM_MINUS   ,"Num -");
+            keyMap.put(KEY_NUM_PLUS   ,"Num +");
+            keyMap.put(KEY_NUM_ENTER   ,"Num Enter");
+            keyMap.put(KEY_NUM_1   ,"Num 1");
+            keyMap.put(KEY_NUM_2   ,"Num 2");
+            keyMap.put(KEY_NUM_3   ,"Num 3");
+            keyMap.put(KEY_NUM_4   ,"Num 4");
+            keyMap.put(KEY_NUM_5   ,"Num 5");
+            keyMap.put(KEY_NUM_6   ,"Num 6");
+            keyMap.put(KEY_NUM_7   ,"Num 7");
+            keyMap.put(KEY_NUM_8   ,"Num 8");
+            keyMap.put(KEY_NUM_9   ,"Num 9");
+            keyMap.put(KEY_NUM_0   ,"Num 0");
+            keyMap.put(KEY_NUM_DOT   ,"Num .");
+            keyMap.put(KEY_A   ,"A");
+            keyMap.put(KEY_B   ,"B");
+            keyMap.put(KEY_C   ,"C");
+            keyMap.put(KEY_D   ,"D");
+            keyMap.put(KEY_E   ,"E");
+            keyMap.put(KEY_F   ,"F");
+            keyMap.put(KEY_G   ,"G");
+            keyMap.put(KEY_H   ,"H");
+            keyMap.put(KEY_I   ,"I");
+            keyMap.put(KEY_J   ,"J");
+            keyMap.put(KEY_K   ,"K");
+            keyMap.put(KEY_L   ,"L");
+            keyMap.put(KEY_M   ,"M");
+            keyMap.put(KEY_N   ,"N");
+            keyMap.put(KEY_O   ,"O");
+            keyMap.put(KEY_P   ,"P");
+            keyMap.put(KEY_Q   ,"Q");
+            keyMap.put(KEY_R   ,"R");
+            keyMap.put(KEY_S   ,"S");
+            keyMap.put(KEY_T   ,"T");
+            keyMap.put(KEY_U   ,"U");
+            keyMap.put(KEY_V   ,"V");
+            keyMap.put(KEY_W   ,"W");
+            keyMap.put(KEY_X   ,"X");
+            keyMap.put(KEY_Y   ,"Y");
+            keyMap.put(KEY_Z   ,"Z");
+            keyMap.put(KEY_MINUS   ,"-");
+            keyMap.put(KEY_EQUALS   ,"=");
+            keyMap.put(KEY_LEFT_BRACKET   ,"[");
+            keyMap.put(KEY_RIGHT_BRACKET   ,"]");
+            keyMap.put(KEY_BACKSLASH   ,"\\"); 
+            keyMap.put(KEY_SEMICOLON   ,";");
+            keyMap.put(KEY_APOSTROPHE   ,"'");
+            keyMap.put(KEY_GRAVE   ,"`");
+            keyMap.put(KEY_COMA   ,",");
+            keyMap.put(KEY_DOT   ,".");
+            keyMap.put(KEY_SLASH   ,"/");
+            keyMap.put(KEY_APPLICATION   ,"Application");
+        }
+
+        public static final int[] ASCIItoHID = {
+            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+            44, 128+30, 128+52, 128+32, 128+33, 128+34, 128+36, 52, 128+38, 128+39, 128+37, 128+46, 54, 45, 55, 56,
+            39, 30, 31, 32, 33, 34, 35, 36, 37, 38, 128+51, 51, 128+54, 46, 128+55, 128+56,
+            128+31, 128+4, 128+5, 128+6, 128+7, 128+8, 128+9, 128+10, 128+11, 128+12, 128+13, 128+14, 128+15, 128+16, 128+17, 128+18, 128+19, 128+20, 128+21, 128+22, 128+23, 128+24, 128+25, 128+26, 128+27, 128+28, 128+29,
+            47, 49, 48, 128+35, 128+45, 53, 
+            4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,
+            128+47, 128+49, 128+48, 128+53, 0 
+        };
+
+        public static char getChar(byte keyCode) { 
+            for (int i = 0; i < ASCIItoHID.length; i++) {
+                    if (ASCIItoHID[i] == (keyCode & 0xFF)) { 
+                            return (char)i;
+                    }
+            }
+            return 0;
+        }
+
+        public static byte getKeyCode(char c) {
+                if (c < ASCIItoHID.length) {
+                        return (byte)ASCIItoHID[c];
+                }
+                return 0;
+        }
+
+        public static int getKeyCode(int c) {
+                if (c < ASCIItoHID.length) {
+                        return ASCIItoHID[c];
+                }
+                return 0;
+        }
+
+        public static String modifiersToString(byte modifiers) {
+            String result = "None";
+            boolean first = true;
+            byte mod;
+            for (int i = 0; i < 8; i++) {
+                    mod = (byte)(CTRL_LEFT << i);
+                    if ((modifiers & mod) != 0) {
+                            if ( !first) {
+                                    result += ", ";
+                            } else {
+                                    result = "";
+                            }
+                            first = false;
+                            result += modifiersMap.get(mod);
+                    }
+            }
+            return result;
+        }
+
+        public static String keyToString(byte key) {
+            String result = keyMap.get(key & 0xFF); 
+            if (result == null) {
+                    result = "Unknown";
+            }
+            return result;
+        }
+}

--- a/app/src/main/java/com/drgraff/speakkey/inputstick/InputStickBroadcast.java
+++ b/app/src/main/java/com/drgraff/speakkey/inputstick/InputStickBroadcast.java
@@ -1,0 +1,221 @@
+package com.drgraff.speakkey.inputstick; // Corrected package
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager.NameNotFoundException;
+
+import com.drgraff.speakkey.inputstick.DownloadDialog; // Corrected import
+import com.drgraff.speakkey.inputstick.Util; // Corrected import
+
+
+public class InputStickBroadcast {
+
+        private static boolean AUTO_SUPPORT_CHECK;
+
+        public static final String PARAM_REQUEST =              "REQUEST";
+        public static final String PARAM_RELEASE =              "RELEASE";
+        public static final String PARAM_CLEAR =                "CLEAR";
+
+        public static final String PARAM_TEXT =                 "TEXT";
+        public static final String PARAM_LAYOUT =               "LAYOUT";
+        public static final String PARAM_MULTIPLIER =   "MULTIPLIER";
+        public static final String PARAM_KEY =                  "KEY";
+        public static final String PARAM_MODIFIER =     "MODIFIER";
+        public static final String PARAM_REPORT_KEYB =  "REPORT_KEYB";
+        public static final String PARAM_REPORT_EMPTY = "REPORT_EMPTY";
+
+        public static final String PARAM_REPORT_MOUSE = "REPORT_MOUSE";
+        public static final String PARAM_MOUSE_BUTTONS ="MOUSE_BUTTONS";
+        public static final String PARAM_MOUSE_CLICKS = "MOUSE_CLICKS";
+
+        public static final String PARAM_CONSUMER =     "CONSUMER";
+
+        public static final String PARAM_REPORT_TOUCH = "REPORT_TOUCHSCREEN";
+        public static final String PARAM_TOUCH_CLICKS = "TOUCH_CLICKS";
+        public static final String PARAM_TOUCH_X =              "TOUCH_X";
+        public static final String PARAM_TOUCH_Y =              "TOUCH_Y";
+
+        public static boolean isSupported(Context ctx, boolean allowMessages) {
+                PackageInfo pInfo;
+                try {
+                        pInfo = ctx.getPackageManager().getPackageInfo("com.inputstick.apps.inputstickutility", 0);
+                        if (pInfo.versionCode < 11) { 
+                                if (allowMessages) {
+                                        DownloadDialog.getDialog(ctx, DownloadDialog.NOT_UPDATED).show();
+                                }
+                                return false;
+                        } else {
+                                return true;
+                        }
+                } catch (NameNotFoundException e) {
+                        if (allowMessages) {
+                                DownloadDialog.getDialog(ctx, DownloadDialog.NOT_INSTALLED).show();
+                        }
+                        return false;
+                }
+        }
+
+        public static void setAutoSupportCheck(boolean enabled) {
+                AUTO_SUPPORT_CHECK = enabled;
+        }
+
+        public static void requestConnection(Context ctx) {
+                Intent intent = new Intent();
+                intent.putExtra(PARAM_REQUEST, true);
+                send(ctx, intent);
+        }
+
+        public static void releaseConnection(Context ctx) {
+                Intent intent = new Intent();
+                intent.putExtra(PARAM_RELEASE, true);
+                send(ctx, intent);
+        }
+
+        public static void clearQueue(Context ctx) {
+                Intent intent = new Intent();
+                intent.putExtra(PARAM_CLEAR, true);
+                send(ctx, intent);
+        }
+
+        public static void type(Context ctx, String text) {
+                type(ctx, text, null, 1);
+        }
+
+        public static void type(Context ctx, String text, String layoutCode) {
+                type(ctx, text, layoutCode, 1);
+        }
+
+        public static void type(Context ctx, String text, String layoutCode, int multiplier) {
+                Intent intent = new Intent();
+                intent.putExtra(PARAM_TEXT, text);
+                if (layoutCode != null) {
+                        intent.putExtra(PARAM_LAYOUT, layoutCode);
+                }
+                if (multiplier > 1) {
+                        intent.putExtra(PARAM_MULTIPLIER, multiplier);
+                }
+                send(ctx, intent);
+        }
+
+        public static void pressAndRelease(Context ctx, byte modifiers, byte key) {
+                pressAndRelease(ctx, modifiers, key, 1);
+        }
+
+        public static void pressAndRelease(Context ctx, byte modifiers, byte key, int multiplier) {
+                Intent intent = new Intent();
+                intent.putExtra(PARAM_MODIFIER, modifiers);
+                intent.putExtra(PARAM_KEY, key);
+                if (multiplier > 1) {
+                        intent.putExtra(PARAM_MULTIPLIER, multiplier);
+                }
+                send(ctx, intent);
+        }
+
+        public static void keyboardReport(Context ctx, byte[] report, boolean addEmptyReport) {
+                Intent intent = new Intent();
+                intent.putExtra(PARAM_REPORT_KEYB, report);
+                if (addEmptyReport) {
+                        intent.putExtra(PARAM_REPORT_EMPTY, true);
+                }
+                send(ctx, intent);
+        }
+
+        public static void keyboardReport(Context ctx, byte modifiers, byte key1, byte key2, byte key3, byte key4, byte key5, byte key6, boolean addEmptyReport) {
+                byte[] report = new byte[8];
+                report[0] = modifiers;
+                report[2] = key1;
+                report[3] = key2;
+                report[4] = key3;
+                report[5] = key4;
+                report[6] = key5;
+                report[7] = key6;
+                keyboardReport(ctx, report, addEmptyReport);
+        }
+
+        public static void mouseReport(Context ctx, byte[] report) {
+                Intent intent = new Intent();
+                intent.putExtra(PARAM_REPORT_MOUSE, report);
+                send(ctx, intent);
+        }
+
+        public static void mouseReport(Context ctx, byte buttons, byte dx, byte dy, byte scroll) {
+                byte[] report = new byte[4];
+                report[0] = buttons;
+                report[1] = dx;
+                report[2] = dy;
+                report[3] = scroll;
+                mouseReport(ctx, report);
+        }
+
+        public static void mouseClick(Context ctx, byte buttons, int n) {
+                Intent intent = new Intent();
+                intent.putExtra(PARAM_MOUSE_BUTTONS, buttons);
+                intent.putExtra(PARAM_MOUSE_CLICKS, n);
+                send(ctx, intent);
+        }
+
+        public static void mouseMove(Context ctx, byte dx, byte dy) {
+                mouseReport(ctx, (byte)0x00, dx, dy, (byte)0x00);
+        }
+
+        public static void mouseScroll(Context ctx, byte scroll) {
+                mouseReport(ctx, (byte)0x00, (byte)0x00, (byte)0x00, scroll);
+        }
+
+        public static void consumerControlAction(Context ctx, int action) {
+                Intent intent = new Intent();
+                intent.putExtra(PARAM_CONSUMER, action);
+                send(ctx, intent);
+        }
+
+        private static void send(Context ctx, Intent intent) {
+                intent.setAction("com.inputstick.apps.inputstickutility.HID");
+                intent.setClassName("com.inputstick.apps.inputstickutility", "com.inputstick.apps.inputstickutility.service.HIDReceiver");
+                if (AUTO_SUPPORT_CHECK) {
+                        if (isSupported(ctx, true)) {
+                                ctx.sendBroadcast(intent);
+                        }
+                } else {
+                        ctx.sendBroadcast(intent);
+                }
+        }
+
+        public static void touchScreenReport(Context ctx, byte[] report) {
+                Intent intent = new Intent();
+                intent.putExtra(PARAM_REPORT_TOUCH, report);
+                send(ctx, intent);
+        }
+
+        public static void touchScreenReport(Context ctx, boolean tipSwitch, boolean inRange, int x, int y) {
+                byte[] report = new byte[6];
+                report[0] = 0x04; // Report ID for TouchScreen
+                if (tipSwitch) {
+                        report[1] = 0x01;
+                }
+                if (inRange) {
+                        report[1] += 0x02;
+                }
+                report[2] = Util.getLSB(x);
+                report[3] = Util.getMSB(x);
+                report[4] = Util.getLSB(y);
+                report[5] = Util.getMSB(y);
+                touchScreenReport(ctx, report);
+        }
+
+        public static void touchScreenMove(Context ctx, int x, int y) {
+                touchScreenReport(ctx, false, true, x, y);
+        }
+
+        public static void touchScreenClick(Context ctx, int n, int x, int y) {
+                Intent intent = new Intent();
+                intent.putExtra(PARAM_TOUCH_CLICKS, n);
+                intent.putExtra(PARAM_TOUCH_X, x);
+                intent.putExtra(PARAM_TOUCH_Y, y);
+                send(ctx, intent);
+        }
+
+        public static void touchScreenGoOutOfRange(Context ctx) {
+                touchScreenReport(ctx, false, false, 0, 0);
+        }
+}

--- a/app/src/main/java/com/drgraff/speakkey/inputstick/Util.java
+++ b/app/src/main/java/com/drgraff/speakkey/inputstick/Util.java
@@ -1,0 +1,220 @@
+package com.drgraff.speakkey.inputstick; // Corrected package
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import android.annotation.SuppressLint;
+import android.util.Log;
+
+public abstract class Util {
+
+        public static final int LOG_MAX_CAPACITY = 500;
+        public static final int FLAG_LOG_API = 0x00000001;
+        public static final int FLAG_LOG_BT_CALLS = 0x00000100;
+        public static final int FLAG_LOG_BT_ADAPTER = 0x00000200;
+        public static final int FLAG_LOG_BT_PACKET = 0x00000400;
+        public static final int FLAG_LOG_BT_EXCEPTION = 0x00000800;
+        public static final int FLAG_LOG_BT_SERVICE = 0x00001000;
+        public static final int FLAG_LOG_UTILITY_CALLS = 0x00010000;
+        public static final int FLAG_LOG_UTILITY_SERVICE = 0x00020000;
+        public static final int FLAG_LOG_UTILITY_UI = 0x00040000;
+        public static final int FLAG_LOG_UTILITY_PACKET = 0x00080000;
+        public static final int FLAG_LOG_UTILITY_EXCEPTION = 0x00100000;
+        public static final int FLAG_NONE = 0x00000000;
+        public static final int FLAG_ALL = 0xFFFFFFFF;
+
+        private static boolean logCatEnabled;
+        private static int eventLogFlags;
+        private static String[] logMessages;
+        private static int[] logFlags;
+        private static long[] logTimeStamps;
+        private static int cnt;
+        private static int totalCnt;
+
+        public static boolean debug = false;
+        public static boolean flashingToolMode = false;
+
+        private static void initLog() {
+                if ((logMessages == null) || (logFlags == null) || (logTimeStamps == null)) {
+                        logMessages = new String[LOG_MAX_CAPACITY];
+                        logFlags = new int[LOG_MAX_CAPACITY];
+                        logTimeStamps = new long[LOG_MAX_CAPACITY];
+                        cnt = 0;
+                        totalCnt = 0;
+                }
+        }
+
+        public static void clearLog() {
+                logMessages = null;
+                logFlags = null;
+                logTimeStamps = null;
+                initLog();
+        }
+
+        public static void setLogOptions(int logFlags, boolean logCat) {
+                eventLogFlags = logFlags;
+                logCatEnabled = logCat;
+        }
+
+        public static void log(int flag, String message) {
+                if ((eventLogFlags & flag) != 0) {
+                        initLog();
+                        logMessages[cnt] = message;
+                        logFlags[cnt] = flag;
+                        logTimeStamps[cnt] = System.currentTimeMillis();
+                        cnt++;
+                        totalCnt++;
+                        if (cnt == LOG_MAX_CAPACITY) {
+                                cnt = 0;
+                        }
+                        if (logCatEnabled) {
+                                String msg;
+                                msg = "[" + getNameOfFlag(flag) + "] " + message;
+                                Log.d("InputStickUtility", msg); // Log tag can be specific to the app
+                        }
+                }
+        }
+
+        public static String getLog(int printFlags) {
+                String result = "";
+                initLog();
+                if (totalCnt == 0) {
+                        return null;
+                } else {
+                        int logged = cnt;
+                        if (totalCnt > LOG_MAX_CAPACITY) { 
+                                logged = LOG_MAX_CAPACITY;
+                        }
+                        result += "[" + System.currentTimeMillis() + "] [LOG] Logged messages: " + logged + " (total: " + totalCnt + ")\n";
+                        int startIdx = (totalCnt <= LOG_MAX_CAPACITY) ? 0 : cnt;
+                        int count = (totalCnt <= LOG_MAX_CAPACITY) ? cnt : LOG_MAX_CAPACITY;
+                        for (int i = 0; i < count; i++) {
+                            int currentIdx = (startIdx + i) % LOG_MAX_CAPACITY;
+                            if (logMessages[currentIdx] != null) {
+                                    result += "[" + logTimeStamps[currentIdx] + "] ";
+                                    result += "[" + getNameOfFlag(logFlags[currentIdx]) + "] ";
+                                    result += logMessages[currentIdx] + "\n";
+                            }
+                        }
+                        return result;
+                }
+        }
+
+        private static String getNameOfFlag(int flag) {
+                switch (flag) {
+                        case FLAG_LOG_BT_PACKET: return "BT PACKET";
+                        case FLAG_LOG_UTILITY_PACKET: return "UTILITY PACKET";
+                        case FLAG_LOG_BT_CALLS: return "BT CALL";
+                        case FLAG_LOG_BT_ADAPTER: return "BT ADAPTER";
+                        case FLAG_LOG_BT_EXCEPTION: return "BT EXCEPTION";
+                        case FLAG_LOG_BT_SERVICE: return "BT SERVICE";
+                        case FLAG_LOG_UTILITY_CALLS: return "UTILITY CALLS";
+                        case FLAG_LOG_UTILITY_SERVICE: return "UTILITY SERVICE";
+                        case FLAG_LOG_UTILITY_UI: return "UTILITY UI";
+                        case FLAG_LOG_UTILITY_EXCEPTION: return "UTILITY EXCEPTION";
+                        case FLAG_LOG_API: return "API";
+                        default: return "UNKNOWN";
+                }
+        }
+
+        public static void printHex(byte[] toPrint, String info) {
+                if (debug) {
+                        System.out.println(info);
+                        printHex(toPrint);
+                }
+        }
+
+        @SuppressLint("DefaultLocale")
+        public static String byteToHexString(byte b) {
+                String s;
+                if ((b < 0x10) && (b >= 0)) {
+                        s = Integer.toHexString((int)b);
+                        s = "0" + s;
+                } else {
+                        s = Integer.toHexString((int)b);
+                        if (s.length() > 2) {
+                                s = s.substring(s.length() - 2);
+                        }
+                }
+                s = s.toUpperCase();
+                return s;
+        }
+
+        public static void printHex(byte[] toPrint) {
+                if (debug) {
+                        if (toPrint != null) {
+                                int localCnt = 0; 
+                                byte b;
+                                for (int i = 0; i < toPrint.length; i++) {
+                                        b = toPrint[i];
+                                        System.out.print("0x" + byteToHexString(b) + " ");
+                                        localCnt++;
+                                        if (localCnt == 8) {
+                                                System.out.println("");
+                                                localCnt = 0;
+                                        }
+                                }
+                        } else {
+                                System.out.println("null");
+                        }
+                        System.out.println("\n#####");
+                }
+        }
+
+        public static byte getLSB(int n) {
+            return (byte)(n & 0x00FF);
+        }
+
+        public static byte getMSB(int n) {
+            return (byte)((n & 0xFF00) >> 8);
+        }
+        
+        public static int getShort(byte[] data, int offset) { 
+            int msbInt = data[offset] & 0xFF;
+            int lsbInt = data[offset+1] & 0xFF;
+            return (msbInt << 8) + lsbInt;
+        }
+
+        public static int getInt(byte b) {
+            int bInt = b & 0xFF;
+            return bInt;
+        }
+
+        public static int getInt(byte msb, byte lsb) {
+            int msbInt = msb & 0xFF;
+            int lsbInt = lsb & 0xFF;
+            return (msbInt << 8) + lsbInt;
+        }
+
+        public static long getLong(byte b0, byte b1, byte b2, byte b3) {
+                long result;
+                result = (b0) & 0xFF;
+                result <<= 8;
+                result += (b1) & 0xFF;
+                result <<= 8;
+                result += (b2) & 0xFF;
+                result <<= 8;
+                result += (b3) & 0xFF;
+                return result;
+        }
+
+        public static byte[] getPasswordBytes(String plainText) {
+                try {
+                        MessageDigest md = MessageDigest.getInstance("MD5");
+                        return md.digest(plainText.getBytes("UTF-8"));
+                } catch (NoSuchAlgorithmException e) {
+                        e.printStackTrace();
+                } catch (UnsupportedEncodingException e) {
+                        e.printStackTrace();
+                }
+                return null;
+        }
+
+        public static String[] convertToStringArray(CharSequence[] charSequences) {
+            String[] result = new String[charSequences.length];
+            for (int i = 0; i < charSequences.length; i++) {
+                result[i] = charSequences[i].toString();
+            }
+            return result;
+        }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,4 +17,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "SpeakKey"
 include ':app'
-include ':inputstickapi'
+// include ':inputstickapi'


### PR DESCRIPTION
This refactors the InputStick integration to use the simpler, broadcast-based approach as suggested by the InputStick API documentation for quick starts. This aims to improve reliability and reduce complexity compared to the previous attempt at a full local API module.

Key changes:
- I isolated the old `inputstickapi` local module by commenting it out in Gradle build files.
- I copied essential InputStick API files directly into the app's source code under the `com.drgraff.speakkey.inputstick` package:
    - `InputStickBroadcast.java`
    - `DownloadDialog.java`
    - `HIDKeycodes.java`
    - `Util.java` Package declarations and internal imports within these files were updated accordingly.
- I modified `MainActivity.java`:
    - I removed usage of the previous `InputStickManager`.
    - I updated the `sendToInputStick()` method to use `InputStickBroadcast.isSupported()` (which prompts for utility app installation if needed via `DownloadDialog`) and `InputStickBroadcast.type()` to send text.
- No layout changes were necessary as the existing UI for sending text to InputStick was compatible with this simplified approach.

This change should make the InputStick feature more robust and easier to maintain. Testing by you is pending.