### PR TITLE
Fix: Add manifest query for InputStickUtility and finalize simplifica…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,4 +51,8 @@
         </activity>
     </application>
 
+    <queries>
+        <package android:name="com.inputstick.apps.inputstickutility" />
+    </queries>
+
 </manifest>


### PR DESCRIPTION
…tion

This commit addresses an issue where the InputStickUtility app was not being detected by the simplified broadcast integration, even when installed. This was due to missing package visibility permissions on Android 11+.

Changes:
- Added a `<queries>` element to `AndroidManifest.xml` to declare the intent to query for `com.inputstick.apps.inputstickutility`.
- This commit also includes the previous changes for simplifying InputStick integration:
    - Isolated the old `inputstickapi` local module.
    - Copied essential API files (`InputStickBroadcast`, `DownloadDialog`, `HIDKeycodes`, `Util`) into the app's main source.
    - Updated `MainActivity` to use the broadcast method for sending text.

With the manifest fix, the app should now correctly detect the InputStickUtility app, allowing the broadcast functionality to work as intended.