### PR TITLE
I've reordered the UI elements for an improved layout.

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -80,50 +80,18 @@
             android:visibility="invisible" />
     </LinearLayout>
 
-    <!-- Whisper Section -->
-    <TextView
-        android:id="@+id/whisper_label"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Whisper Transcription"
-        android:layout_marginTop="16dp"
-        android:textStyle="bold"
-        app:layout_constraintTop_toBottomOf="@id/recording_indicator_layout"
-        app:layout_constraintStart_toStartOf="parent" />
-
-    <EditText
-        android:id="@+id/whisper_text"
-        android:layout_width="match_parent"
-        android:layout_height="180dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginBottom="8dp"
-        android:background="@color/edit_text_background"
-        android:hint="Transcribed text will appear here"
-        android:padding="8dp"
-        android:paddingEnd="12dp"
-        android:gravity="top|start"
-        android:inputType="textMultiLine"
-        android:drawableEnd="?android:attr/actionModeWebSearchDrawable"
-        android:focusable="false"
-        android:clickable="true"
-        android:scrollbars="vertical"
-        android:fadeScrollbars="false"
-        android:nestedScrollingEnabled="true"
-        android:minLines="3"
-        android:maxLines="100"
-        app:layout_constraintTop_toBottomOf="@id/whisper_label"
-        app:layout_constraintBottom_toTopOf="@id/whisper_controls" />
-
+    <!-- Whisper Controls -->
     <LinearLayout
         android:id="@+id/whisper_controls"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:gravity="center_horizontal"
-        app:layout_constraintTop_toBottomOf="@id/whisper_text">
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toBottomOf="@id/recording_indicator_layout">
 
         <LinearLayout
-            android:layout_width="wrap_content" 
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:gravity="center_vertical">
@@ -139,7 +107,7 @@
                 android:id="@+id/chk_auto_send_whisper"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Auto-send"/> 
+                android:text="Auto-send"/>
         </LinearLayout>
 
         <LinearLayout
@@ -166,6 +134,78 @@
         </LinearLayout>
     </LinearLayout>
 
+    <!-- Whisper Section -->
+    <TextView
+        android:id="@+id/whisper_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Whisper Transcription"
+        android:layout_marginTop="16dp"
+        android:textStyle="bold"
+        app:layout_constraintTop_toBottomOf="@id/whisper_controls"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <EditText
+        android:id="@+id/whisper_text"
+        android:layout_width="match_parent"
+        android:layout_height="180dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:background="@color/edit_text_background"
+        android:hint="Transcribed text will appear here"
+        android:padding="8dp"
+        android:paddingEnd="12dp"
+        android:gravity="top|start"
+        android:inputType="textMultiLine"
+        android:drawableEnd="?android:attr/actionModeWebSearchDrawable"
+        android:focusable="false"
+        android:clickable="true"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="false"
+        android:nestedScrollingEnabled="true"
+        android:minLines="3"
+        android:maxLines="100"
+        app:layout_constraintTop_toBottomOf="@id/whisper_label"
+        app:layout_constraintBottom_toTopOf="@id/chatgpt_controls" />
+
+    <!-- ChatGPT Controls -->
+    <LinearLayout
+        android:id="@+id/chatgpt_controls"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center_horizontal"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toBottomOf="@id/whisper_text">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <Button
+                android:id="@+id/btn_send_chatgpt"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/send_to_chatgpt"
+                android:layout_marginEnd="8dp"/> <!-- Adjust margin -->
+
+            <CheckBox
+                android:id="@+id/chk_auto_send_to_chatgpt"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Auto-send"/>
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/btn_clear_chatgpt"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/clear_chatgpt_response"
+            android:layout_marginTop="8dp"/> <!-- Add margin -->
+    </LinearLayout>
+
     <!-- ChatGPT Section -->
     <TextView
         android:id="@+id/chatgpt_label"
@@ -174,7 +214,7 @@
         android:text="ChatGPT Response"
         android:layout_marginTop="16dp"
         android:textStyle="bold"
-        app:layout_constraintTop_toBottomOf="@id/whisper_controls"
+        app:layout_constraintTop_toBottomOf="@id/chatgpt_controls"
         app:layout_constraintStart_toStartOf="parent" />
 
     <EditText
@@ -198,43 +238,7 @@
         android:minLines="3"
         android:maxLines="100"
         app:layout_constraintTop_toBottomOf="@id/chatgpt_label"
-        app:layout_constraintBottom_toTopOf="@id/chatgpt_controls" />
-
-    <LinearLayout
-        android:id="@+id/chatgpt_controls"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical" 
-        android:gravity="center_horizontal" 
-        app:layout_constraintTop_toBottomOf="@id/chatgpt_text">
-
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:gravity="center_vertical">
-
-            <Button
-                android:id="@+id/btn_send_chatgpt"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/send_to_chatgpt"
-                android:layout_marginEnd="8dp"/> <!-- Adjust margin -->
-
-            <CheckBox
-                android:id="@+id/chk_auto_send_to_chatgpt"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Auto-send"/> 
-        </LinearLayout>
-
-        <Button
-            android:id="@+id/btn_clear_chatgpt"
-            android:layout_width="wrap_content" 
-            android:layout_height="wrap_content"
-            android:text="@string/clear_chatgpt_response"
-            android:layout_marginTop="8dp"/> <!-- Add margin -->
-    </LinearLayout>
+        app:layout_constraintBottom_toTopOf="@id/inputstick_controls" />
 
     <!-- InputStick Section -->
     <LinearLayout
@@ -244,7 +248,7 @@
         android:orientation="horizontal"
         android:gravity="center"
         android:layout_marginTop="16dp"
-        app:layout_constraintTop_toBottomOf="@id/chatgpt_controls"
+        app:layout_constraintTop_toBottomOf="@id/chatgpt_text"
         app:layout_constraintBottom_toBottomOf="parent">
 
         <Button


### PR DESCRIPTION
- The Whisper controls (Send button, Auto-send checkbox, Clear buttons) are now above the Whisper Transcription text box.
- The ChatGPT controls (Send button, Auto-send checkbox) are now above the ChatGPT Response text box, while remaining below the Whisper section.
- I've adjusted all relevant layout constraints in `content_main.xml` to ensure proper alignment and display of the reordered elements.