### PR TITLE
Fix: Add missing dimens.xml resource file

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="macro_button_margin_horizontal">4dp</dimen>
+</resources>


### PR DESCRIPTION
- Created `app/src/main/res/values/dimens.xml`.
- Defined `macro_button_margin_horizontal` (4dp) within this file.

This resolves the build error 'cannot find symbol R.dimen.macro_button_margin_horizontal' in MainActivity.java.