### PR TITLE
Fix: Add missing styles.xml to potentially resolve crash

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- You can add custom styles here later if needed. -->
+    <!-- For example, if SpeakKey had specific text appearances or button styles not covered by MaterialComponents directly -->
+
+    <!-- Example of a custom style (can be left out if not immediately needed):
+    <style name="MyCustomTextStyle">
+        <item name="android:textColor">@color/primary</item>
+        <item name="android:textSize">18sp</item>
+    </style>
+    -->
+</resources>


### PR DESCRIPTION
- I created a minimal `app/src/main/res/values/styles.xml` file.

This is an attempt to resolve a runtime crash when opening the Macros screen, on the hypothesis that the build system or layout inflaters might require this file's presence, even if most styles are inherited from the Material Components theme via themes.xml.