### PR TITLE
Fix: Declare Macro activities in AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,13 @@
             android:theme="@style/Theme.SpeakKey"
             android:parentActivityName=".MainActivity">
         </activity>
+
+        <activity
+            android:name="com.speakkey.ui.macros.MacroListActivity"
+            android:label="Manage Macros" />
+        <activity
+            android:name="com.speakkey.ui.macros.MacroEditorActivity"
+            android:label="Edit Macro" />
     </application>
 
     <queries>


### PR DESCRIPTION
- I added <activity> declarations for com.speakkey.ui.macros.MacroListActivity and com.speakkey.ui.macros.MacroEditorActivity in AndroidManifest.xml.

This resolves the ActivityNotFoundException crash when you try to navigate to the macros feature.