### PR TITLE
Fix: Update Macros screen UI elements

### DIFF
--- a/app/src/main/res/layout/activity_macros.xml
+++ b/app/src/main/res/layout/activity_macros.xml
@@ -15,7 +15,7 @@
             android:id="@+id/toolbar_macros"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
-            android:background="?attr/colorPrimary"
+            android:background="@android:color/black"
             app:popupTheme="@style/Theme.SpeakKey.PopupOverlay" />
 
     </com.google.android.material.appbar.AppBarLayout>
@@ -37,7 +37,8 @@
         android:visibility="gone"
         app:layout_anchor="@id/macros_recycler_view"
         app:layout_anchorGravity="center"
-        tools:visibility="visible"/>
+        tools:visibility="visible"
+        android:layout_marginTop="24dp"/>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab_add_macro"

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -14,5 +14,13 @@
         
         <!-- Status bar color -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
+        <item name="alertDialogTheme">@style/AppAlertDialogTheme</item>
+    </style>
+
+    <style name="AppAlertDialogTheme" parent="ThemeOverlay.MaterialComponents.Dialog.Alert">
+        <item name="buttonBarPositiveButtonStyle">@style/AlertDialog.Button.Positive</item>
+        <item name="buttonBarNegativeButtonStyle">@style/AlertDialog.Button.Negative</item>
+        <!-- You might also need to set colorPrimary for button backgrounds if they are not appearing correctly -->
+        <!-- <item name="colorPrimary">@color/primaryLight</item> -->
     </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -9,4 +9,11 @@
         <item name="android:textSize">18sp</item>
     </style>
     -->
+
+    <style name="AlertDialog.Button.Positive" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
+        <item name="android:textColor">@android:color/white</item>
+    </style>
+    <style name="AlertDialog.Button.Negative" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
+        <item name="android:textColor">@android:color/white</item>
+    </style>
 </resources>


### PR DESCRIPTION
- I changed the AlertDialog button text color to white in dark mode for MacroEditorActivity.
- I adjusted the position of "No macros found" text in MacroListActivity to prevent overlap with the toolbar.
- I set the MacroListActivity toolbar background to black to match the rest of the app theme.