### PR TITLE
Fix: Correct positioning of "No macros found" text

### DIFF
--- a/app/src/main/res/layout/activity_macros.xml
+++ b/app/src/main/res/layout/activity_macros.xml
@@ -35,10 +35,9 @@
         android:text="No macros found. Tap the '+' button to create one."
         android:textSize="16sp"
         android:visibility="gone"
-        app:layout_anchor="@id/macros_recycler_view"
-        app:layout_anchorGravity="center"
+        android:layout_gravity="top|center_horizontal"
         tools:visibility="visible"
-        android:layout_marginTop="24dp"/>
+        android:layout_marginTop="56dp"/>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab_add_macro"


### PR DESCRIPTION
Re-adjusted the layout attributes for the "No macros found" text view in MacroListActivity to prevent it from overlapping with the toolbar. Set layout_gravity to top|center_horizontal and increased marginTop.