### PR TITLE
Fix: Change Macros screen Up button color to gray

### DIFF
--- a/app/src/main/java/com/speakkey/ui/macros/MacroListActivity.kt
+++ b/app/src/main/java/com/speakkey/ui/macros/MacroListActivity.kt
@@ -2,7 +2,9 @@ package com.speakkey.ui.macros
 
 import android.app.Activity
 import android.content.Intent
+import android.graphics.PorterDuff
 import android.os.Bundle
+import androidx.core.content.ContextCompat
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -42,6 +44,7 @@ class MacroListActivity : AppCompatActivity() {
         setSupportActionBar(toolbar)
         supportActionBar?.title = "Macros"
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        toolbar.navigationIcon?.setColorFilter(ContextCompat.getColor(this, R.color.gray), PorterDuff.Mode.SRC_ATOP)
 
         macroRepository = MacroRepository(applicationContext)
         recyclerView = findViewById(R.id.macros_recycler_view)


### PR DESCRIPTION
I've updated MacroListActivity to set the color of the Up button (back arrow) in the toolbar to gray (#757575) to match the styling of other screens in your application.