### PR TITLE
Fix: Navigation drawer item text and icon color in dark mode

### DIFF
--- a/app/src/main/res/color/drawer_item_tint_color.xml
+++ b/app/src/main/res/color/drawer_item_tint_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true" android:color="@android:color/white" />
+    <item android:color="?android:attr/textColorSecondary" /> <!-- Default color -->
+</selector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -22,6 +22,8 @@
         android:layout_gravity="start"
         android:fitsSystemWindows="true"
         app:headerLayout="@layout/nav_header_main"
-        app:menu="@menu/menu_drawer" />
+        app:menu="@menu/menu_drawer"
+        app:itemTextColor="@color/drawer_item_tint_color"
+        app:itemIconTint="@color/drawer_item_tint_color" />
 
 </androidx.drawerlayout.widget.DrawerLayout>


### PR DESCRIPTION
- I created a new color state list (drawer_item_tint_color.xml) to define text and icon colors for navigation drawer items.
- I ensured that checked/selected items use white color for text and icon, improving readability in dark mode.
- I applied this color state list to the NavigationView in activity_main.xml using app:itemTextColor and app:itemIconTint attributes.