### PR TITLE
Fix: Resolve build error due to missing Retrofit GET import

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/api/ChatGptApiService.java
+++ b/app/src/main/java/com/drgraff/speakkey/api/ChatGptApiService.java
@@ -2,6 +2,7 @@ package com.drgraff.speakkey.api;
 
 import retrofit2.Call;
 import retrofit2.http.Body;
+import retrofit2.http.GET; // Added
 import retrofit2.http.Header;
 import retrofit2.http.POST;
 


### PR DESCRIPTION
I added the missing import for `retrofit2.http.GET` in ChatGptApiService.java. This resolves the "cannot find symbol class GET" compilation error that occurred when building the dynamic ChatGPT model fetching feature.