### PR TITLE
Fix: Navigation drawer header overlapping with status bar

### DIFF
--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -10,7 +10,8 @@
     android:paddingTop="16dp"
     android:paddingRight="16dp"
     android:paddingBottom="16dp"
-    android:theme="@style/ThemeOverlay.AppCompat.Dark">
+    android:theme="@style/ThemeOverlay.AppCompat.Dark"
+    android:fitsSystemWindows="true">
 
     <TextView
         android:layout_width="match_parent"


### PR DESCRIPTION
I've added `android:fitsSystemWindows="true"` to the root `LinearLayout` of the navigation drawer header layout (`nav_header_main.xml`). This ensures that the header content is correctly positioned below the system status bar, preventing overlap.