### PR TITLE
Refactor: Reduce vertical spacing on main UI

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -69,7 +69,7 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:gravity="center_vertical"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="2dp"
         app:layout_constraintTop_toBottomOf="@id/recording_controls"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
@@ -98,7 +98,7 @@
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:gravity="center_horizontal"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="2dp"
         app:layout_constraintTop_toBottomOf="@id/recording_indicator_layout">
 
         <LinearLayout
@@ -153,7 +153,7 @@
         android:id="@+id/whisper_text"
         android:layout_width="match_parent"
         android:layout_height="180dp"
-        android:layout_marginTop="4dp"
+        android:layout_marginTop="0dp"
         android:layout_marginBottom="4dp"
         android:background="@color/edit_text_background"
         android:hint="Transcribed text will appear here"
@@ -216,7 +216,7 @@
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:gravity="center_horizontal"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="2dp"
         app:layout_constraintTop_toBottomOf="@id/btn_clear_transcription"
         app:layout_constraintBottom_toTopOf="@id/chatgpt_text">
 


### PR DESCRIPTION
This commit adjusts layout margins in `content_main.xml` to reduce excessive vertical space between several UI elements, based on your feedback.

Specific changes:

1.  **Whisper Transcription Area:**
    *   Reduced the `marginTop` of the `whisper_text` EditText from `4dp` to `0dp` to bring it immediately below its `whisper_label`, making it consistent with the perceived spacing of the ChatGPT section.

2.  **Record and "Send to Whisper" Buttons:**
    *   Reduced `marginTop` of `recording_indicator_layout` (between record buttons and whisper controls) from `8dp` to `2dp`.
    *   Reduced `marginTop` of `whisper_controls` (containing "Send to Whisper" button) from `8dp` to `2dp`.
    This significantly tightens the space between these two control groups.

3.  **Buttons Below Whisper and ChatGPT Response:**
    *   Reduced `marginTop` of `chatgpt_controls` (which is above the ChatGPT label and EditText) from `8dp` to `2dp`, decreasing the gap from the `btn_clear_transcription`.

These changes aim to create a more compact and visually efficient main user interface.