### PR TITLE
Feat: Add "Clear All" button functionality

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -65,7 +65,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     private DrawerLayout drawerLayout;
     private Button btnStartRecording, btnPauseRecording, btnStopRecording;
     private Button btnSendWhisper, btnClearRecording, btnClearTranscription;
-    private Button btnSendChatGpt, btnClearChatGpt;
+    private Button btnSendChatGpt, btnClearChatGpt, btnClearAll; // Added btnClearAll
     private Button btnSendInputStick;
     private Button btnSendWhisperToInputStick; // Added
     private EditText whisperText, chatGptText;
@@ -174,6 +174,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         chkAutoSendInputStick = findViewById(R.id.chk_auto_send_inputstick);
         btnSendWhisperToInputStick = findViewById(R.id.btn_send_whisper_to_inputstick);
         chk_auto_send_whisper_to_inputstick = findViewById(R.id.chk_auto_send_whisper_to_inputstick);
+        btnClearAll = findViewById(R.id.btn_clear_all); // Initialize btnClearAll
 
         // Set up click listeners
         // setupClickListeners(); // Moved down
@@ -277,6 +278,22 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         chk_auto_send_whisper_to_inputstick.setOnCheckedChangeListener((buttonView, isChecked) -> { // Added
             sharedPreferences.edit().putBoolean("auto_send_whisper_to_inputstick", isChecked).apply();
         });
+
+        if (btnClearAll != null) {
+            btnClearAll.setOnClickListener(v -> {
+                clearRecording(); // Clears the audio file and recording duration
+
+                if (whisperText != null) {
+                    whisperText.setText("");
+                }
+
+                if (chatGptText != null) {
+                    chatGptText.setText("");
+                }
+                
+                Toast.makeText(MainActivity.this, "All fields cleared", Toast.LENGTH_SHORT).show();
+            });
+        }
     }
     
     private void requestPermissions() {

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -134,6 +134,13 @@
                 android:layout_height="wrap_content"
                 android:text="@string/clear_recording"/> <!-- Small margin between buttons -->
 
+            <Button
+                android:id="@+id/btn_clear_all"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/clear_all_button_text"
+                android:layout_marginStart="8dp"/>
+
             <!-- btn_clear_transcription was removed from here -->
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="clear_chatgpt_response">Clear Response</string>
     <string name="send_to_inputstick">Send to InputStick</string>
     <string name="save_edit">Save</string> <!-- String for Save button in full-screen edit dialog -->
+    <string name="clear_all_button_text">Clear All</string>
     
     <!-- Settings -->
     <string name="title_activity_settings">Settings</string>


### PR DESCRIPTION
This commit introduces a new "Clear All" button to the main UI, located next to the "Clear Recording" button.

The "Clear All" button performs the following actions upon being clicked:
1.  Clears the current audio recording (by invoking the existing `clearRecording()` method).
2.  Clears the text from the Whisper transcription EditText.
3.  Clears the text from the ChatGPT response EditText.
4.  Displays a Toast message to confirm that all fields have been cleared.

Layout changes were made in `content_main.xml` to include the new button, and a corresponding string resource `clear_all_button_text` was added to `strings.xml`. The core logic is implemented in `MainActivity.java`, including button initialization and its `OnClickListener`.