### PR TITLE
Refactor: Replace "Clear Transcript" button with an icon

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -15,6 +15,7 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
+import android.widget.ImageButton; // Added for ImageButton
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -64,7 +65,8 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     // UI elements
     private DrawerLayout drawerLayout;
     private Button btnStartRecording, btnPauseRecording, btnStopRecording;
-    private Button btnSendWhisper, btnClearRecording, btnClearTranscription;
+    private Button btnSendWhisper, btnClearRecording; // Removed btnClearTranscription
+    private ImageButton btnClearTranscriptionIcon; // Added
     private Button btnSendChatGpt, btnClearChatGpt, btnClearAll; // Added btnClearAll
     private Button btnSendInputStick;
     private Button btnSendWhisperToInputStick; // Added
@@ -160,7 +162,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         whisperText = findViewById(R.id.whisper_text);
         btnSendWhisper = findViewById(R.id.btn_send_whisper);
         btnClearRecording = findViewById(R.id.btn_clear_recording);
-        btnClearTranscription = findViewById(R.id.btn_clear_transcription);
+        btnClearTranscriptionIcon = findViewById(R.id.btn_clear_transcription_icon); // Initialize new ImageButton
         chkAutoSendWhisper = findViewById(R.id.chk_auto_send_whisper);
         
         // ChatGPT section
@@ -256,7 +258,11 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         
         btnSendWhisper.setOnClickListener(v -> transcribeAudio());
         btnClearRecording.setOnClickListener(v -> clearRecording());
-        btnClearTranscription.setOnClickListener(v -> clearTranscription());
+        // btnClearTranscription.setOnClickListener(v -> clearTranscription()); // Removed old listener
+
+        if (btnClearTranscriptionIcon != null) {
+            btnClearTranscriptionIcon.setOnClickListener(v -> clearTranscription());
+        }
         
         btnSendChatGpt.setOnClickListener(v -> sendToChatGpt());
         btnClearChatGpt.setOnClickListener(v -> clearChatGptResponse());

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -156,6 +156,19 @@
         app:layout_constraintTop_toBottomOf="@id/whisper_controls"
         app:layout_constraintStart_toStartOf="parent" />
 
+    <ImageButton
+        android:id="@+id/btn_clear_transcription_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@android:drawable/ic_menu_delete"
+        android:contentDescription="@string/clear_transcription"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:padding="4dp"
+        android:layout_marginStart="8dp"
+        app:layout_constraintStart_toEndOf="@id/whisper_label"
+        app:layout_constraintTop_toTopOf="@id/whisper_label"
+        app:layout_constraintBottom_toBottomOf="@id/whisper_label"/>
+
     <EditText
         android:id="@+id/whisper_text"
         android:layout_width="match_parent"
@@ -189,7 +202,9 @@
         app:layout_constraintTop_toBottomOf="@id/whisper_text"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/btn_clear_transcription">
+        app:layout_constraintBottom_toTopOf="@id/chatgpt_controls"> 
+        <!-- The Button @+id/btn_clear_transcription was here. 
+             The bottom constraint of whisper_to_inputstick_controls needs to point to chatgpt_controls -->
 
         <Button
             android:id="@+id/btn_send_whisper_to_inputstick"
@@ -205,16 +220,7 @@
             android:text="Auto-send"/>
     </LinearLayout>
 
-    <Button
-        android:id="@+id/btn_clear_transcription"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/clear_transcription"
-        android:layout_marginTop="2dp"
-        app:layout_constraintTop_toBottomOf="@id/whisper_to_inputstick_controls"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/chatgpt_controls"/>
+    <!-- The Button @+id/btn_clear_transcription was here and is now removed. -->
 
     <!-- ChatGPT Controls -->
     <LinearLayout
@@ -224,7 +230,7 @@
         android:orientation="vertical"
         android:gravity="center_horizontal"
         android:layout_marginTop="0dp"
-        app:layout_constraintTop_toBottomOf="@id/btn_clear_transcription"
+        app:layout_constraintTop_toBottomOf="@id/whisper_to_inputstick_controls" 
         app:layout_constraintBottom_toTopOf="@id/chatgpt_text">
 
         <LinearLayout


### PR DESCRIPTION
This commit refactors the UI for clearing the Whisper transcription. The text-based "Clear Transcript" button has been removed and replaced with an ImageButton using a standard delete (garbage can) icon.

Key changes:

1.  **Layout (`content_main.xml`):**
    *   Removed the `Button` with ID `@+id/btn_clear_transcription`.
    *   Added a new `ImageButton` with ID `@+id/btn_clear_transcription_icon` positioned next to the "Whisper Transcription" label (`@+id/whisper_label`).
    *   The new `ImageButton` uses `@android:drawable/ic_menu_delete` as its source and `@string/clear_transcription` for its content description.
    *   Layout constraints for elements previously dependent on the old button have been updated to maintain the correct UI flow.

2.  **Logic (`MainActivity.java`):**
    *   Removed code references (field, initialization, listener setup) for the old `btn_clear_transcription`.
    *   Added a new field for `btnClearTranscriptionIcon` and initialized it.
    *   The `OnClickListener` for `btnClearTranscriptionIcon` now calls the existing `clearTranscription()` method, which handles clearing the `whisperText` EditText and also clears the associated audio recording.

This change provides a more compact UI by utilizing an icon for a common action, consistent with modern UI practices. The functionality remains the same.