### PR TITLE
Refactor: Replace "Clear Response" button with an icon for ChatGPT

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -67,7 +67,8 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     private Button btnStartRecording, btnPauseRecording, btnStopRecording;
     private Button btnSendWhisper, btnClearRecording; // Removed btnClearTranscription
     private ImageButton btnClearTranscriptionIcon; // Added
-    private Button btnSendChatGpt, btnClearChatGpt, btnClearAll; // Added btnClearAll
+    private Button btnSendChatGpt, btnClearAll; // Removed btnClearChatGpt, Added btnClearAll
+    private ImageButton btnClearChatGptIcon; // Added
     private Button btnSendInputStick;
     private Button btnSendWhisperToInputStick; // Added
     private EditText whisperText, chatGptText;
@@ -168,7 +169,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         // ChatGPT section
         chatGptText = findViewById(R.id.chatgpt_text);
         btnSendChatGpt = findViewById(R.id.btn_send_chatgpt);
-        btnClearChatGpt = findViewById(R.id.btn_clear_chatgpt);
+        btnClearChatGptIcon = findViewById(R.id.btn_clear_chatgpt_icon); // Initialize new ImageButton
         chkAutoSendToChatGpt = findViewById(R.id.chk_auto_send_to_chatgpt);
         
         // InputStick section
@@ -265,7 +266,11 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         }
         
         btnSendChatGpt.setOnClickListener(v -> sendToChatGpt());
-        btnClearChatGpt.setOnClickListener(v -> clearChatGptResponse());
+        // btnClearChatGpt.setOnClickListener(v -> clearChatGptResponse()); // Removed old listener
+
+        if (btnClearChatGptIcon != null) {
+            btnClearChatGptIcon.setOnClickListener(v -> clearChatGptResponse());
+        }
         
         btnSendInputStick.setOnClickListener(v -> sendToInputStick());
         

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -267,6 +267,19 @@
         app:layout_constraintTop_toBottomOf="@id/chatgpt_controls"
         app:layout_constraintStart_toStartOf="parent" />
 
+    <ImageButton
+        android:id="@+id/btn_clear_chatgpt_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@android:drawable/ic_menu_delete"
+        android:contentDescription="@string/clear_chatgpt_response"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:padding="4dp"
+        android:layout_marginStart="8dp"
+        app:layout_constraintStart_toEndOf="@id/chatgpt_label"
+        app:layout_constraintTop_toTopOf="@id/chatgpt_label"
+        app:layout_constraintBottom_toBottomOf="@id/chatgpt_label"/>
+
     <EditText
         android:id="@+id/chatgpt_text"
         android:layout_width="match_parent"
@@ -298,8 +311,9 @@
         android:orientation="horizontal"
         android:gravity="center"
         android:layout_marginTop="4dp"
+        android:layout_marginBottom="2dp"
         app:layout_constraintTop_toBottomOf="@id/chatgpt_text"
-        app:layout_constraintBottom_toTopOf="@id/btn_clear_chatgpt">
+        app:layout_constraintBottom_toBottomOf="parent">
 
         <Button
             android:id="@+id/btn_send_inputstick"
@@ -316,17 +330,7 @@
             <!-- Removed original layout_margin, relying on button's marginEnd -->
     </LinearLayout>
 
-    <Button
-        android:id="@+id/btn_clear_chatgpt"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/clear_chatgpt_response"
-        android:layout_marginTop="2dp"
-        android:layout_marginBottom="2dp"
-        app:layout_constraintTop_toBottomOf="@id/inputstick_controls"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+    <!-- The Button @+id/btn_clear_chatgpt was here and is now removed. -->
 
 </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>


### PR DESCRIPTION
This commit mirrors the previous UI enhancement for "Clear Transcript" by replacing the text-based "Clear Response" button (for the ChatGPT section) with an ImageButton using a standard delete (garbage can) icon.

Key changes:

1.  **Layout (`content_main.xml`):**
    *   Removed the `Button` with ID `@+id/btn_clear_chatgpt`.
    *   Added a new `ImageButton` with ID `@+id/btn_clear_chatgpt_icon` positioned next to the "ChatGPT Response" label (`@+id/chatgpt_label`).
    *   The new `ImageButton` uses `@android:drawable/ic_menu_delete` as its source and `@string/clear_chatgpt_response` for its content description.
    *   Layout constraints for `@+id/inputstick_controls` (which was above the old button) have been updated to correctly anchor it to the bottom of the parent layout.

2.  **Logic (`MainActivity.java`):**
    *   Removed code references (field, initialization, listener setup) for the old `btn_clear_chatgpt`.
    *   Added a new field for `btnClearChatgptIcon` and initialized it.
    *   The `OnClickListener` for `btnClearChatgptIcon` now calls the existing `clearChatGptResponse()` method, which handles clearing the `chatGptText` EditText.

This change further enhances UI consistency and compactness by utilizing an icon for the clear action in the ChatGPT section, similar to the Whisper section.