### PR TITLE
Fix: Add spacing below ChatGPT response label

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -284,7 +284,7 @@
         android:id="@+id/chatgpt_text"
         android:layout_width="match_parent"
         android:layout_height="180dp"
-        android:layout_marginTop="0dp"
+        android:layout_marginTop="8dp"
         android:layout_marginBottom="2dp"
         android:background="@color/edit_text_background"
         android:hint="ChatGPT response will appear here"


### PR DESCRIPTION
I increased the top margin of the ChatGPT response text box (`chatgpt_text`) to 8dp in `app/src/main/res/layout/content_main.xml`.

This adds a small amount of vertical space between the "ChatGPT Response" label (and its associated clear icon) and the EditText field below it, preventing them from appearing obscured or too close together.