### PR TITLE
Feat: Replace Whisper clear buttons with a single icon

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -65,9 +65,10 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     // UI elements
     private DrawerLayout drawerLayout;
     private Button btnStartRecording, btnPauseRecording, btnStopRecording;
-    private Button btnSendWhisper, btnClearRecording; // Removed btnClearTranscription
+    private Button btnSendWhisper; // Removed btnClearTranscription, Removed btnClearRecording
     private ImageButton btnClearTranscriptionIcon; // Added
-    private Button btnSendChatGpt, btnClearAll; // Removed btnClearChatGpt, Added btnClearAll
+    private ImageButton btnClearAllWhisperIcon; // Added to replace btnClearAll
+    private Button btnSendChatGpt; // Removed btnClearChatGpt
     private ImageButton btnClearChatGptIcon; // Added
     private Button btnSendInputStick;
     private Button btnSendWhisperToInputStick; // Added
@@ -162,7 +163,8 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         // Whisper section
         whisperText = findViewById(R.id.whisper_text);
         btnSendWhisper = findViewById(R.id.btn_send_whisper);
-        btnClearRecording = findViewById(R.id.btn_clear_recording);
+        // btnClearRecording = findViewById(R.id.btn_clear_recording); // Removed
+        btnClearAllWhisperIcon = findViewById(R.id.btn_clear_all_whisper_icon); // Added
         btnClearTranscriptionIcon = findViewById(R.id.btn_clear_transcription_icon); // Initialize new ImageButton
         chkAutoSendWhisper = findViewById(R.id.chk_auto_send_whisper);
         
@@ -177,7 +179,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         chkAutoSendInputStick = findViewById(R.id.chk_auto_send_inputstick);
         btnSendWhisperToInputStick = findViewById(R.id.btn_send_whisper_to_inputstick);
         chk_auto_send_whisper_to_inputstick = findViewById(R.id.chk_auto_send_whisper_to_inputstick);
-        btnClearAll = findViewById(R.id.btn_clear_all); // Initialize btnClearAll
+        // btnClearAll = findViewById(R.id.btn_clear_all); // Removed
 
         // Set up click listeners
         // setupClickListeners(); // Moved down
@@ -258,7 +260,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         btnStopRecording.setOnClickListener(v -> stopRecording());
         
         btnSendWhisper.setOnClickListener(v -> transcribeAudio());
-        btnClearRecording.setOnClickListener(v -> clearRecording());
+        // btnClearRecording.setOnClickListener(v -> clearRecording()); // Removed
         // btnClearTranscription.setOnClickListener(v -> clearTranscription()); // Removed old listener
 
         if (btnClearTranscriptionIcon != null) {
@@ -290,8 +292,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             sharedPreferences.edit().putBoolean("auto_send_whisper_to_inputstick", isChecked).apply();
         });
 
-        if (btnClearAll != null) {
-            btnClearAll.setOnClickListener(v -> {
+        // Listener for the new ImageButton btnClearAllWhisperIcon
+        if (btnClearAllWhisperIcon != null) {
+            btnClearAllWhisperIcon.setOnClickListener(v -> {
                 clearRecording(); // Clears the audio file and recording duration
 
                 if (whisperText != null) {
@@ -305,6 +308,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                 Toast.makeText(MainActivity.this, "All fields cleared", Toast.LENGTH_SHORT).show();
             });
         }
+        // The old btnClearAll listener is removed by not including it here.
     }
     
     private void requestPermissions() {

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -119,29 +119,16 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Auto-send"/>
-        </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginTop="2dp"> <!-- Add some top margin -->
-
-            <Button
-                android:id="@+id/btn_clear_recording"
+            <ImageButton
+                android:id="@+id/btn_clear_all_whisper_icon"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/clear_recording"/> <!-- Small margin between buttons -->
-
-            <Button
-                android:id="@+id/btn_clear_all"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/clear_all_button_text"
+                android:src="@android:drawable/ic_menu_delete"
+                android:contentDescription="@string/clear_all_content_description"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:padding="4dp"
                 android:layout_marginStart="8dp"/>
-
-            <!-- btn_clear_transcription was removed from here -->
         </LinearLayout>
     </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="send_to_inputstick">Send to InputStick</string>
     <string name="save_edit">Save</string> <!-- String for Save button in full-screen edit dialog -->
     <string name="clear_all_button_text">Clear All</string>
+    <string name="clear_all_content_description">Clear all text fields</string>
     
     <!-- Settings -->
     <string name="title_activity_settings">Settings</string>


### PR DESCRIPTION
Replaced the "Clear Recording" and "Clear All" buttons in the Whisper controls section with a single garbage can icon (`btn_clear_all_whisper_icon`).

Changes:
- Modified `app/src/main/res/layout/content_main.xml`:
    - Removed the `LinearLayout` containing `btn_clear_recording` and `btn_clear_all`.
    - Added an `ImageButton` with ID `btn_clear_all_whisper_icon` next to the `chk_auto_send_whisper` checkbox.
- Updated `app/src/main/java/com/drgraff/speakkey/MainActivity.java`:
    - Transferred the click listener logic from the old `btn_clear_all` to the new `btn_clear_all_whisper_icon`.
    - Removed references and listeners for `btn_clear_recording` and the old `btn_clear_all`.
- Added a new string resource `clear_all_content_description` to `app/src/main/res/values/strings.xml` for the new icon's content description.

The new icon now performs the "Clear All" functionality, which includes clearing the recorded audio, the Whisper transcription text, and the ChatGPT response text.