### PR TITLE
Fix: Macro edit screen button text color in light mode

### DIFF
--- a/app/src/main/res/layout/activity_edit_macro.xml
+++ b/app/src/main/res/layout/activity_edit_macro.xml
@@ -131,8 +131,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:layout_marginEnd="8dp"
-                android:text="Cancel"
-                android:textColor="@android:color/white"/>
+                android:text="Cancel"/>
 
             <Button
                 android:id="@+id/btn_save_macro"
@@ -140,8 +139,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:layout_marginStart="8dp"
-                android:text="Save Macro"
-                android:textColor="@android:color/white"/>
+                android:text="Save Macro"/>
         </LinearLayout>
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
Removed the hardcoded `android:textColor="@android:color/white"` from the "Cancel" (`btn_cancel_macro_edit`) and "Save Macro" (`btn_save_macro`) buttons in
`app/src/main/res/layout/activity_edit_macro.xml`.

This fixes an issue where the button text was invisible in light mode (white text on a light background). By removing the hardcoded color, the `Widget.MaterialComponents.Button.TextButton` style can now correctly apply theme-appropriate text colors for both light and dark modes.