### PR TITLE
Fix: Correct invalid characters in preferences summary

### DIFF
--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -69,7 +69,7 @@
         <SwitchPreferenceCompat
             android:key="pref_inputstick_format_tags_enabled"
             android:title="Enable Text Formatting Tags"
-            android:summary="Convert tags like <b>, <i> to Ctrl+B, Ctrl+I"
+            android:summary="Convert tags (e.g., 'b', 'i') to Ctrl+B, Ctrl+I"
             android:defaultValue="false" />
 
         <EditTextPreference


### PR DESCRIPTION
Resolved an XML parsing error in `app/src/main/res/xml/root_preferences.xml`. The `android:summary` attribute for the `SwitchPreferenceCompat` with key `pref_inputstick_format_tags_enabled` contained unescaped '<' and '>' characters (from HTML-like tags `<b>` and `<i>`).

Changed the summary from "Convert tags like `<b>`, `<i>` to Ctrl+B, Ctrl+I" to "Convert tags (e.g., 'b', 'i') to Ctrl+B, Ctrl+I" to avoid this parsing issue. This should allow the build to complete successfully.