### PR TITLE
Fix: Correct HIDKeycode for Ctrl and document API assumption

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/inputstick/TextTagFormatter.java
+++ b/app/src/main/java/com/drgraff/speakkey/inputstick/TextTagFormatter.java
@@ -89,14 +89,22 @@ public class TextTagFormatter {
         // For the purpose of this subtask, creating the structure is key.
         // A more robust way is to send raw reports or use a specific API if InputStickBroadcast supports it.
         // Let's assume a hypothetical method or sequence:
-        InputStickBroadcast.reportKeyboard(context, HIDKeycodes.MOD_CTRL_LEFT, HIDKeycodes.KEY_B, (byte)0, (byte)0, (byte)0, (byte)0, (byte)0, (byte)0); // Press Ctrl+B
+        // for pressing/releasing modifier and character keys individually if this fails.
+        // and may need to be replaced with the correct API calls from InputStickBroadcast
+        // The 'reportKeyboard' method and its signature used below are an assumption
+        // TODO: Verify InputStick API for sending Ctrl+Key combinations.
+        InputStickBroadcast.reportKeyboard(context, HIDKeycodes.CTRL_LEFT, HIDKeycodes.KEY_B, (byte)0, (byte)0, (byte)0, (byte)0, (byte)0, (byte)0); // Press Ctrl+B
         InputStickBroadcast.reportKeyboard(context, (byte)0, (byte)0, (byte)0, (byte)0, (byte)0, (byte)0, (byte)0, (byte)0); // Release all
     }
 
     private void sendCtrlI(Context context) {
         Log.d(TAG, "Sending Ctrl+I");
         // Placeholder similar to sendCtrlB
-        InputStickBroadcast.reportKeyboard(context, HIDKeycodes.MOD_CTRL_LEFT, HIDKeycodes.KEY_I, (byte)0, (byte)0, (byte)0, (byte)0, (byte)0, (byte)0); // Press Ctrl+I
+        // for pressing/releasing modifier and character keys individually if this fails.
+        // and may need to be replaced with the correct API calls from InputStickBroadcast
+        // The 'reportKeyboard' method and its signature used below are an assumption
+        // TODO: Verify InputStick API for sending Ctrl+Key combinations.
+        InputStickBroadcast.reportKeyboard(context, HIDKeycodes.CTRL_LEFT, HIDKeycodes.KEY_I, (byte)0, (byte)0, (byte)0, (byte)0, (byte)0, (byte)0); // Press Ctrl+I
         InputStickBroadcast.reportKeyboard(context, (byte)0, (byte)0, (byte)0, (byte)0, (byte)0, (byte)0, (byte)0, (byte)0); // Release all
     }
 


### PR DESCRIPTION
I corrected the HIDKeycode constant used for the Control key in `TextTagFormatter.java` from `MOD_CTRL_LEFT` to `CTRL_LEFT`.

Additionally, I added comments to the `sendCtrlB` and `sendCtrlI` methods to highlight that the usage of
`InputStickBroadcast.reportKeyboard()` and its specific signature is an assumption. This part of the code may need further adjustment based on the actual InputStickBroadcast API for sending complex keystroke combinations if build errors related to this method persist.

This addresses the `cannot find symbol: MOD_CTRL_LEFT` error.