### PR TITLE
Fix: Prevent crash in settings due to duplicate SummaryProvider

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/settings/SettingsActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/settings/SettingsActivity.java
@@ -84,12 +84,6 @@ public class SettingsActivity extends AppCompatActivity {
             prefCheckModelsButton = findPreference("pref_check_models_button");
             // Preference checkUpdatesPreference = findPreference("pref_check_for_updates"); // Removed
 
-            EditTextPreference formatDelayPreference = findPreference("pref_inputstick_format_delay_ms");
-            if (formatDelayPreference != null) {
-                String currentValue = sharedPreferences.getString("pref_inputstick_format_delay_ms", "100");
-                formatDelayPreference.setSummary(currentValue + " ms");
-            }
-
             String apiKey = sharedPreferences.getString("openai_api_key", "");
             if (!apiKey.isEmpty()) {
                 chatGptApi = new ChatGptApi(apiKey, sharedPreferences.getString("chatgpt_model", "gpt-3.5-turbo"));
@@ -269,12 +263,6 @@ public class SettingsActivity extends AppCompatActivity {
                     if (listPref.getEntry() != null) {
                         listPref.setSummary(listPref.getEntry());
                     }
-                }
-            } else if (key.equals("pref_inputstick_format_delay_ms")) {
-                Preference delayPref = findPreference(key);
-                if (delayPref instanceof EditTextPreference) {
-                    String currentValue = sharedPreferences.getString(key, "100");
-                    delayPref.setSummary(currentValue + " ms");
                 }
             }
         }


### PR DESCRIPTION
The application was crashing when opening the settings menu because a SummaryProvider was being set twice for the 'pref_inputstick_format_delay_ms' EditTextPreference:
1. Declaratively in the XML using `app:useSimpleSummaryProvider="true"`.
2. Programmatically in `SettingsActivity.java` within `onCreatePreferences` and `onSharedPreferenceChanged`.

This commit resolves the `IllegalStateException` by removing the programmatic summary updates in `SettingsActivity.java`. The summary will now be solely handled by the `useSimpleSummaryProvider` attribute, which displays the preference's value directly. This means the " ms" suffix will no longer be appended to the summary for this specific preference, but it ensures the stability of the settings screen.