### PR TITLE
feat: Implement user-defined Formatting Tags management

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -42,6 +42,7 @@ import com.speakkey.service.MacroExecutor; // Added for Macro Execution
 import com.drgraff.speakkey.inputstick.InputStickBroadcast; // Added
 // import com.drgraff.speakkey.inputstick.InputStickManager; // Removed
 import com.drgraff.speakkey.settings.SettingsActivity;
+import com.drgraff.speakkey.formattingtags.FormattingTagsActivity; // Added for Formatting Tags
 import com.speakkey.ui.macros.MacroListActivity; // Added for Macros
 import com.drgraff.speakkey.utils.AppLogManager;
 import com.drgraff.speakkey.utils.ThemeManager;
@@ -658,6 +659,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             startActivity(intent);
         } else if (id == R.id.nav_macros) {
             Intent intent = new Intent(this, MacroListActivity.class); // This line remains as is, assuming MacroListActivity is still the target for "Macros"
+            startActivity(intent);
+        } else if (id == R.id.nav_formatting_tags) { // New block
+            Intent intent = new Intent(this, com.drgraff.speakkey.formattingtags.FormattingTagsActivity.class);
             startActivity(intent);
         }
         

--- a/app/src/main/java/com/drgraff/speakkey/formattingtags/EditFormattingTagActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/formattingtags/EditFormattingTagActivity.java
@@ -1,0 +1,142 @@
+package com.drgraff.speakkey.formattingtags;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.view.MenuItem;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+
+import com.drgraff.speakkey.R;
+import com.google.android.material.textfield.TextInputEditText;
+
+
+public class EditFormattingTagActivity extends AppCompatActivity {
+
+    public static final String EXTRA_TAG_ID = "com.drgraff.speakkey.EXTRA_TAG_ID";
+    private static final long INVALID_TAG_ID = -1;
+
+    private TextInputEditText editTextName, editTextOpeningTag, editTextClosingTag, editTextKeystrokeSequence;
+    private Button buttonSave;
+    private FormattingTagManager tagManager;
+    private FormattingTag currentTag;
+    private long currentTagId = INVALID_TAG_ID;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_edit_formatting_tag);
+
+        Toolbar toolbar = findViewById(R.id.toolbar_edit_formatting_tag);
+        setSupportActionBar(toolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+            // Title will be set below based on add/edit mode
+        }
+
+        editTextName = findViewById(R.id.edit_tag_name);
+        editTextOpeningTag = findViewById(R.id.edit_tag_opening_text);
+        editTextClosingTag = findViewById(R.id.edit_tag_closing_text);
+        editTextKeystrokeSequence = findViewById(R.id.edit_tag_keystroke_sequence);
+        buttonSave = findViewById(R.id.button_save_formatting_tag);
+
+        tagManager = new FormattingTagManager(this);
+        tagManager.open();
+
+        currentTagId = getIntent().getLongExtra(EXTRA_TAG_ID, INVALID_TAG_ID);
+
+        if (currentTagId != INVALID_TAG_ID) {
+            currentTag = tagManager.getTag(currentTagId);
+            if (currentTag != null) {
+                editTextName.setText(currentTag.getName());
+                editTextOpeningTag.setText(currentTag.getOpeningTagText());
+                editTextClosingTag.setText(currentTag.getClosingTagText());
+                editTextKeystrokeSequence.setText(currentTag.getKeystrokeSequence());
+                if (getSupportActionBar() != null) {
+                    getSupportActionBar().setTitle(getString(R.string.edit_formatting_tag_title));
+                }
+            } else {
+                Toast.makeText(this, "Error: Formatting tag not found.", Toast.LENGTH_LONG).show();
+                if (getSupportActionBar() != null) {
+                    getSupportActionBar().setTitle(getString(R.string.add_new_formatting_tag_title));
+                }
+                // Treat as new if tag not found, currentTagId remains invalid for save logic
+                currentTagId = INVALID_TAG_ID;
+            }
+        } else {
+            if (getSupportActionBar() != null) {
+                getSupportActionBar().setTitle(getString(R.string.add_new_formatting_tag_title));
+            }
+        }
+
+        buttonSave.setOnClickListener(v -> saveFormattingTag());
+    }
+
+    private void saveFormattingTag() {
+        String name = editTextName.getText().toString().trim();
+        String openingText = editTextOpeningTag.getText().toString().trim();
+        String closingText = editTextClosingTag.getText().toString().trim(); // Can be empty
+        String keystrokes = editTextKeystrokeSequence.getText().toString().trim();
+
+        if (name.isEmpty()) {
+            editTextName.setError(getString(R.string.tag_name_required_message));
+            editTextName.requestFocus();
+            Toast.makeText(this, getString(R.string.tag_name_required_message), Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        if (openingText.isEmpty()) {
+            editTextOpeningTag.setError(getString(R.string.opening_tag_text_required_message));
+            editTextOpeningTag.requestFocus();
+            Toast.makeText(this, getString(R.string.opening_tag_text_required_message), Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        if (keystrokes.isEmpty()) {
+            editTextKeystrokeSequence.setError(getString(R.string.keystroke_sequence_required_message));
+            editTextKeystrokeSequence.requestFocus();
+            Toast.makeText(this, getString(R.string.keystroke_sequence_required_message), Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        if (currentTagId != INVALID_TAG_ID && currentTag != null) {
+            // Editing existing tag
+            currentTag.setName(name);
+            currentTag.setOpeningTagText(openingText);
+            currentTag.setClosingTagText(closingText);
+            currentTag.setKeystrokeSequence(keystrokes);
+            // currentTag.setActive(true); // Assuming active, or add a switch
+            tagManager.updateTag(currentTag);
+        } else {
+            // Adding new tag
+            // ID 0 is fine as SQLite will auto-increment. isActive defaults to true in DB.
+            FormattingTag newTag = new FormattingTag(0, name, openingText, closingText, keystrokes, true);
+            tagManager.addTag(newTag);
+        }
+
+        Toast.makeText(this, getString(R.string.formatting_tag_saved_message), Toast.LENGTH_SHORT).show();
+        setResult(Activity.RESULT_OK);
+        finish();
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (tagManager != null) {
+            tagManager.close();
+        }
+    }
+}

--- a/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTag.java
+++ b/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTag.java
@@ -1,0 +1,110 @@
+package com.drgraff.speakkey.formattingtags;
+
+import java.util.Objects;
+
+public class FormattingTag {
+
+    private long id;
+    private String name;
+    private String openingTagText;
+    private String closingTagText;
+    private String keystrokeSequence;
+    private boolean isActive;
+
+    // Default constructor
+    public FormattingTag() {
+    }
+
+    // Constructor for all fields (id can be set later or auto-generated)
+    public FormattingTag(String name, String openingTagText, String closingTagText, String keystrokeSequence, boolean isActive) {
+        this.name = name;
+        this.openingTagText = openingTagText;
+        this.closingTagText = closingTagText;
+        this.keystrokeSequence = keystrokeSequence;
+        this.isActive = isActive;
+    }
+
+    // Constructor including id
+    public FormattingTag(long id, String name, String openingTagText, String closingTagText, String keystrokeSequence, boolean isActive) {
+        this.id = id;
+        this.name = name;
+        this.openingTagText = openingTagText;
+        this.closingTagText = closingTagText;
+        this.keystrokeSequence = keystrokeSequence;
+        this.isActive = isActive;
+    }
+
+    // Getters and Setters
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getOpeningTagText() {
+        return openingTagText;
+    }
+
+    public void setOpeningTagText(String openingTagText) {
+        this.openingTagText = openingTagText;
+    }
+
+    public String getClosingTagText() {
+        return closingTagText;
+    }
+
+    public void setClosingTagText(String closingTagText) {
+        this.closingTagText = closingTagText;
+    }
+
+    public String getKeystrokeSequence() {
+        return keystrokeSequence;
+    }
+
+    public void setKeystrokeSequence(String keystrokeSequence) {
+        this.keystrokeSequence = keystrokeSequence;
+    }
+
+    public boolean isActive() {
+        return isActive;
+    }
+
+    public void setActive(boolean active) {
+        isActive = active;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FormattingTag that = (FormattingTag) o;
+        return id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return "FormattingTag{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", openingTagText='" + openingTagText + '\'' +
+                ", closingTagText='" + closingTagText + '\'' +
+                ", keystrokeSequence='" + keystrokeSequence + '\'' +
+                ", isActive=" + isActive +
+                '}';
+    }
+}

--- a/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTagAdapter.java
+++ b/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTagAdapter.java
@@ -1,0 +1,143 @@
+package com.drgraff.speakkey.formattingtags;
+
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageButton;
+import android.widget.TextView;
+import android.widget.Toast;
+import androidx.annotation.NonNull;
+import androidx.appcompat.widget.SwitchCompat;
+import androidx.recyclerview.widget.RecyclerView;
+import com.drgraff.speakkey.R;
+// Import EditFormattingTagActivity once it's created
+// import com.drgraff.speakkey.formattingtags.EditFormattingTagActivity;
+
+import java.util.List;
+
+public class FormattingTagAdapter extends RecyclerView.Adapter<FormattingTagAdapter.FormattingTagViewHolder> {
+
+    private List<FormattingTag> formattingTags;
+    private final Context context;
+    private final FormattingTagManager tagManager;
+    private static final String TAG = "FormattingTagAdapter";
+
+    public FormattingTagAdapter(Context context, List<FormattingTag> formattingTags, FormattingTagManager tagManager) {
+        this.context = context;
+        this.formattingTags = formattingTags;
+        this.tagManager = tagManager;
+    }
+
+    @NonNull
+    @Override
+    public FormattingTagViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View itemView = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.list_item_formatting_tag, parent, false);
+        return new FormattingTagViewHolder(itemView);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull FormattingTagViewHolder holder, int position) {
+        FormattingTag currentTag = formattingTags.get(position);
+
+        holder.tagNameTextView.setText(currentTag.getName());
+        holder.tagOpeningTextView.setText(currentTag.getOpeningTagText());
+        holder.tagKeystrokesTextView.setText(currentTag.getKeystrokeSequence());
+        holder.tagActiveSwitch.setChecked(currentTag.isActive());
+
+        // Remove previous listeners to prevent multiple triggers
+        holder.tagActiveSwitch.setOnCheckedChangeListener(null);
+        holder.editButton.setOnClickListener(null);
+        holder.deleteButton.setOnClickListener(null);
+
+
+        holder.tagActiveSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            currentTag.setActive(isChecked);
+            try {
+                tagManager.open();
+                tagManager.updateTag(currentTag); // Assuming updateTag method exists in FormattingTagManager
+            } catch (Exception e) {
+                Log.e(TAG, "Error updating tag active state", e);
+                Toast.makeText(context, "Error updating tag", Toast.LENGTH_SHORT).show();
+                // Revert switch state if update failed
+                buttonView.setChecked(!isChecked);
+                currentTag.setActive(!isChecked); // Revert in the model as well
+            } finally {
+                tagManager.close();
+            }
+        });
+
+        holder.editButton.setOnClickListener(v -> {
+            // Intent intent = new Intent(context, EditFormattingTagActivity.class);
+            // intent.putExtra(EditFormattingTagActivity.EXTRA_TAG_ID, currentTag.getId());
+            // context.startActivity(intent);
+            // For now, as EditFormattingTagActivity doesn't exist, we can log or Toast
+            Log.d(TAG, "Edit button clicked for tag ID: " + currentTag.getId());
+            Toast.makeText(context, "Edit for tag: " + currentTag.getName(), Toast.LENGTH_SHORT).show();
+            // TODO: Replace with actual Intent when EditFormattingTagActivity is available
+             if (context instanceof FormattingTagsActivity) {
+                Intent intent = new Intent(context, EditFormattingTagActivity.class); // Assuming EditFormattingTagActivity will be created
+                intent.putExtra("EXTRA_TAG_ID", currentTag.getId());
+                ((FormattingTagsActivity) context).startActivityForResult(intent, FormattingTagsActivity.REQUEST_CODE_EDIT_TAG);
+            }
+        });
+
+        holder.deleteButton.setOnClickListener(v -> {
+            int currentPosition = holder.getAdapterPosition();
+            if (currentPosition != RecyclerView.NO_POSITION) {
+                FormattingTag tagToDelete = formattingTags.get(currentPosition);
+                try {
+                    tagManager.open();
+                    tagManager.deleteTag(tagToDelete.getId()); // Assuming deleteTag method exists
+                    formattingTags.remove(currentPosition);
+                    notifyItemRemoved(currentPosition);
+                    // Corrected the range for notifyItemRangeChanged
+                    notifyItemRangeChanged(currentPosition, formattingTags.size() - currentPosition);
+                    Toast.makeText(context, context.getString(R.string.formatting_tag_deleted_message), Toast.LENGTH_SHORT).show();
+                } catch (Exception e) {
+                    Log.e(TAG, "Error deleting tag", e);
+                    Toast.makeText(context, "Error deleting tag", Toast.LENGTH_SHORT).show();
+                } finally {
+                    tagManager.close();
+                }
+            }
+        });
+    }
+
+    @Override
+    public int getItemCount() {
+        return formattingTags == null ? 0 : formattingTags.size();
+    }
+
+    public void setFormattingTags(List<FormattingTag> newTags) {
+        if (newTags == null) {
+            this.formattingTags.clear();
+        } else {
+            this.formattingTags = newTags; // Directly assign if the list is managed externally or a new list is preferred
+            // Or, if you want to add to the existing list instance:
+            // this.formattingTags.clear();
+            // this.formattingTags.addAll(newTags);
+        }
+        notifyDataSetChanged();
+    }
+
+
+    static class FormattingTagViewHolder extends RecyclerView.ViewHolder {
+        TextView tagNameTextView, tagOpeningTextView, tagKeystrokesTextView;
+        SwitchCompat tagActiveSwitch;
+        ImageButton editButton, deleteButton;
+
+        public FormattingTagViewHolder(@NonNull View itemView) {
+            super(itemView);
+            tagNameTextView = itemView.findViewById(R.id.tag_name_text_view);
+            tagOpeningTextView = itemView.findViewById(R.id.tag_opening_text_view);
+            tagKeystrokesTextView = itemView.findViewById(R.id.tag_keystrokes_text_view);
+            tagActiveSwitch = itemView.findViewById(R.id.tag_active_switch);
+            editButton = itemView.findViewById(R.id.tag_edit_button);
+            deleteButton = itemView.findViewById(R.id.tag_delete_button);
+        }
+    }
+}

--- a/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTagDbHelper.java
+++ b/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTagDbHelper.java
@@ -1,0 +1,45 @@
+package com.drgraff.speakkey.formattingtags;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+
+public class FormattingTagDbHelper extends SQLiteOpenHelper {
+
+    public static final String DATABASE_NAME = "formatting_tags.db";
+    public static final int DATABASE_VERSION = 1;
+
+    public static final String TABLE_FORMATTING_TAGS = "formatting_tags";
+    public static final String COLUMN_ID = "_id"; // Standard convention for primary key
+    public static final String COLUMN_NAME = "name";
+    public static final String COLUMN_OPENING_TAG_TEXT = "opening_tag_text";
+    public static final String COLUMN_CLOSING_TAG_TEXT = "closing_tag_text";
+    public static final String COLUMN_KEYSTROKE_SEQUENCE = "keystroke_sequence";
+    public static final String COLUMN_IS_ACTIVE = "is_active";
+
+    private static final String TABLE_CREATE =
+            "CREATE TABLE " + TABLE_FORMATTING_TAGS + " (" +
+                    COLUMN_ID + " INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                    COLUMN_NAME + " TEXT NOT NULL, " +
+                    COLUMN_OPENING_TAG_TEXT + " TEXT NOT NULL UNIQUE, " +
+                    COLUMN_CLOSING_TAG_TEXT + " TEXT NOT NULL, " +
+                    COLUMN_KEYSTROKE_SEQUENCE + " TEXT NOT NULL, " +
+                    COLUMN_IS_ACTIVE + " INTEGER NOT NULL DEFAULT 1" + // Default to true (1)
+                    ");";
+
+    public FormattingTagDbHelper(Context context) {
+        super(context, DATABASE_NAME, null, DATABASE_VERSION);
+    }
+
+    @Override
+    public void onCreate(SQLiteDatabase db) {
+        db.execSQL(TABLE_CREATE);
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        // Simple upgrade policy: drop table and recreate
+        db.execSQL("DROP TABLE IF EXISTS " + TABLE_FORMATTING_TAGS);
+        onCreate(db);
+    }
+}

--- a/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTagManager.java
+++ b/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTagManager.java
@@ -1,0 +1,226 @@
+package com.drgraff.speakkey.formattingtags;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.SQLException;
+import android.database.sqlite.SQLiteDatabase;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FormattingTagManager {
+
+    private SQLiteDatabase database;
+    private FormattingTagDbHelper dbHelper;
+    private static final String TAG = "FormattingTagManager";
+
+    public FormattingTagManager(Context context) {
+        dbHelper = new FormattingTagDbHelper(context.getApplicationContext());
+    }
+
+    public void open() throws SQLException {
+        // Ensure any existing database instance is closed before opening a new one
+        // or simply re-assign. SQLiteOpenHelper handles underlying DB management.
+        database = dbHelper.getWritableDatabase();
+        Log.d(TAG, "Database opened.");
+    }
+
+    public void close() {
+        if (database != null && database.isOpen()) {
+            // database.close(); // This is often handled by dbHelper.close()
+        }
+        if (dbHelper != null) {
+            dbHelper.close(); // This will close the database if it's open.
+            Log.d(TAG, "Database helper closed.");
+        }
+    }
+
+    public boolean isOpen() {
+        return database != null && database.isOpen();
+    }
+
+    public long addTag(FormattingTag tag) {
+        if (database == null || !database.isOpen()) {
+            Log.w(TAG, "Database is not open. Call open() before addTag.");
+            // Optionally, open it here if this behavior is desired:
+            // open(); 
+            return -1; // Or throw an exception
+        }
+        ContentValues values = new ContentValues();
+        values.put(FormattingTagDbHelper.COLUMN_NAME, tag.getName());
+        values.put(FormattingTagDbHelper.COLUMN_OPENING_TAG_TEXT, tag.getOpeningTagText());
+        values.put(FormattingTagDbHelper.COLUMN_CLOSING_TAG_TEXT, tag.getClosingTagText());
+        values.put(FormattingTagDbHelper.COLUMN_KEYSTROKE_SEQUENCE, tag.getKeystrokeSequence());
+        values.put(FormattingTagDbHelper.COLUMN_IS_ACTIVE, tag.isActive() ? 1 : 0);
+
+        try {
+            long insertId = database.insert(FormattingTagDbHelper.TABLE_FORMATTING_TAGS, null, values);
+            tag.setId(insertId); // Set the ID on the passed object
+            return insertId;
+        } catch (SQLException e) {
+            Log.e(TAG, "Error inserting tag: " + e.getMessage());
+            return -1;
+        }
+    }
+
+    public FormattingTag getTag(long id) {
+        if (database == null || !database.isOpen()) {
+            Log.w(TAG, "Database is not open. Call open() before getTag.");
+            return null;
+        }
+        Cursor cursor = null;
+        FormattingTag tag = null;
+        try {
+            cursor = database.query(FormattingTagDbHelper.TABLE_FORMATTING_TAGS,
+                    null, // All columns
+                    FormattingTagDbHelper.COLUMN_ID + " = ?",
+                    new String[]{String.valueOf(id)},
+                    null, null, null);
+
+            if (cursor != null && cursor.moveToFirst()) {
+                tag = cursorToFormattingTag(cursor);
+            }
+        } catch (SQLException e) {
+            Log.e(TAG, "Error getting tag with id " + id + ": " + e.getMessage());
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+        return tag;
+    }
+
+    public List<FormattingTag> getAllTags() {
+        if (database == null || !database.isOpen()) {
+            Log.w(TAG, "Database is not open. Call open() before getAllTags.");
+            return new ArrayList<>(); // Return empty list if DB not open
+        }
+        List<FormattingTag> tags = new ArrayList<>();
+        Cursor cursor = null;
+        try {
+            cursor = database.query(FormattingTagDbHelper.TABLE_FORMATTING_TAGS,
+                    null, // All columns
+                    null, null, null, null,
+                    FormattingTagDbHelper.COLUMN_NAME + " ASC");
+
+            if (cursor != null && cursor.moveToFirst()) {
+                while (!cursor.isAfterLast()) {
+                    FormattingTag tag = cursorToFormattingTag(cursor);
+                    tags.add(tag);
+                    cursor.moveToNext();
+                }
+            }
+        } catch (SQLException e) {
+            Log.e(TAG, "Error getting all tags: " + e.getMessage());
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+        return tags;
+    }
+
+    public int updateTag(FormattingTag tag) {
+        if (database == null || !database.isOpen()) {
+            Log.w(TAG, "Database is not open. Call open() before updateTag.");
+            return 0;
+        }
+        ContentValues values = new ContentValues();
+        values.put(FormattingTagDbHelper.COLUMN_NAME, tag.getName());
+        values.put(FormattingTagDbHelper.COLUMN_OPENING_TAG_TEXT, tag.getOpeningTagText());
+        values.put(FormattingTagDbHelper.COLUMN_CLOSING_TAG_TEXT, tag.getClosingTagText());
+        values.put(FormattingTagDbHelper.COLUMN_KEYSTROKE_SEQUENCE, tag.getKeystrokeSequence());
+        values.put(FormattingTagDbHelper.COLUMN_IS_ACTIVE, tag.isActive() ? 1 : 0);
+
+        try {
+            return database.update(FormattingTagDbHelper.TABLE_FORMATTING_TAGS,
+                    values,
+                    FormattingTagDbHelper.COLUMN_ID + " = ?",
+                    new String[]{String.valueOf(tag.getId())});
+        } catch (SQLException e) {
+            Log.e(TAG, "Error updating tag with id " + tag.getId() + ": " + e.getMessage());
+            return 0;
+        }
+    }
+
+    public boolean deleteTag(long id) {
+        if (database == null || !database.isOpen()) {
+            Log.w(TAG, "Database is not open. Call open() before deleteTag.");
+            return false;
+        }
+        try {
+            int rowsAffected = database.delete(FormattingTagDbHelper.TABLE_FORMATTING_TAGS,
+                    FormattingTagDbHelper.COLUMN_ID + " = ?",
+                    new String[]{String.valueOf(id)});
+            return rowsAffected > 0;
+        } catch (SQLException e) {
+            Log.e(TAG, "Error deleting tag with id " + id + ": " + e.getMessage());
+            return false;
+        }
+    }
+
+    private FormattingTag cursorToFormattingTag(Cursor cursor) {
+        FormattingTag tag = new FormattingTag();
+        // Ensure to get column indices dynamically to avoid issues if column order changes
+        int idIndex = cursor.getColumnIndex(FormattingTagDbHelper.COLUMN_ID);
+        int nameIndex = cursor.getColumnIndex(FormattingTagDbHelper.COLUMN_NAME);
+        int openingTagIndex = cursor.getColumnIndex(FormattingTagDbHelper.COLUMN_OPENING_TAG_TEXT);
+        int closingTagIndex = cursor.getColumnIndex(FormattingTagDbHelper.COLUMN_CLOSING_TAG_TEXT);
+        int keystrokeIndex = cursor.getColumnIndex(FormattingTagDbHelper.COLUMN_KEYSTROKE_SEQUENCE);
+        int isActiveIndex = cursor.getColumnIndex(FormattingTagDbHelper.COLUMN_IS_ACTIVE);
+
+        if (idIndex != -1) tag.setId(cursor.getLong(idIndex));
+        if (nameIndex != -1) tag.setName(cursor.getString(nameIndex));
+        if (openingTagIndex != -1) tag.setOpeningTagText(cursor.getString(openingTagIndex));
+        if (closingTagIndex != -1) tag.setClosingTagText(cursor.getString(closingTagIndex));
+        if (keystrokeIndex != -1) tag.setKeystrokeSequence(cursor.getString(keystrokeIndex));
+        if (isActiveIndex != -1) tag.setActive(cursor.getInt(isActiveIndex) == 1);
+        
+        return tag;
+    }
+
+    public List<FormattingTag> getActiveTags() {
+        if (database == null || !database.isOpen()) {
+            Log.w(TAG, "Database is not open in getActiveTags. Returning empty list.");
+            // Consider throwing an exception or ensuring 'open()' is called if this state is unexpected.
+            // For now, returning an empty list to prevent crashes if 'open()' was missed.
+            return new ArrayList<>();
+        }
+
+        List<FormattingTag> activeTags = new ArrayList<>();
+        Cursor cursor = null;
+        try {
+            String selection = FormattingTagDbHelper.COLUMN_IS_ACTIVE + " = ?";
+            String[] selectionArgs = { "1" };
+            // Optional: Add an order by clause, e.g., by name or by length of opening tag text
+            // String orderBy = FormattingTagDbHelper.COLUMN_NAME + " ASC";
+            String orderBy = "LENGTH(" + FormattingTagDbHelper.COLUMN_OPENING_TAG_TEXT + ") DESC, " + FormattingTagDbHelper.COLUMN_NAME + " ASC";
+
+
+            cursor = database.query(
+                    FormattingTagDbHelper.TABLE_FORMATTING_TAGS,
+                    null, // All columns
+                    selection,
+                    selectionArgs,
+                    null, // groupBy
+                    null, // having
+                    orderBy // orderBy
+            );
+
+            if (cursor != null) {
+                while (cursor.moveToNext()) {
+                    activeTags.add(cursorToFormattingTag(cursor));
+                }
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Error getting active tags", e);
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+        return activeTags;
+    }
+}

--- a/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTagsActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTagsActivity.java
@@ -1,0 +1,123 @@
+package com.drgraff.speakkey.formattingtags;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import com.drgraff.speakkey.R;
+// Import EditFormattingTagActivity once it's created
+// import com.drgraff.speakkey.formattingtags.EditFormattingTagActivity;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FormattingTagsActivity extends AppCompatActivity {
+
+    private RecyclerView recyclerView;
+    private FormattingTagAdapter adapter;
+    private FormattingTagManager tagManager;
+    private TextView emptyView;
+    private FloatingActionButton fabAddTag;
+
+    public static final int REQUEST_CODE_ADD_TAG = 1;
+    public static final int REQUEST_CODE_EDIT_TAG = 2;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_formatting_tags);
+
+        Toolbar toolbar = findViewById(R.id.toolbar_formatting_tags);
+        setSupportActionBar(toolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+            getSupportActionBar().setTitle(getString(R.string.formatting_tags_activity_title));
+        }
+
+        recyclerView = findViewById(R.id.formatting_tags_recycler_view);
+        emptyView = findViewById(R.id.empty_formatting_tags_text_view);
+        fabAddTag = findViewById(R.id.fab_add_formatting_tag);
+
+        tagManager = new FormattingTagManager(this);
+
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        // Initialize with an empty list; loadFormattingTags will populate it.
+        adapter = new FormattingTagAdapter(this, new ArrayList<>(), tagManager);
+        recyclerView.setAdapter(adapter);
+
+        fabAddTag.setOnClickListener(v -> {
+            // Intent intent = new Intent(FormattingTagsActivity.this, EditFormattingTagActivity.class);
+            // startActivityForResult(intent, REQUEST_CODE_ADD_TAG);
+            // For now, as EditFormattingTagActivity doesn't exist:
+            Intent intent = new Intent(FormattingTagsActivity.this, EditFormattingTagActivity.class); // Assuming EditFormattingTagActivity will be created
+            startActivityForResult(intent, REQUEST_CODE_ADD_TAG);
+        });
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        loadFormattingTags();
+    }
+
+    private void loadFormattingTags() {
+        List<FormattingTag> tags = new ArrayList<>(); // Default to empty list
+        try {
+            tagManager.open();
+            // Assuming getAllTags will be implemented in FormattingTagManager
+            // For now, it might return an empty list or throw if not implemented.
+             if (tagManager.isOpen()) { // Ensure manager is open
+                tags = tagManager.getAllTags(); // This method needs to be implemented in FormattingTagManager
+             }
+        } catch (Exception e) {
+            // Log error or show a toast
+            android.util.Log.e("FormattingTagsActivity", "Error loading tags", e);
+        } finally {
+            if (tagManager.isOpen()) {
+                tagManager.close();
+            }
+        }
+
+        adapter.setFormattingTags(tags);
+
+        if (tags.isEmpty()) {
+            recyclerView.setVisibility(View.GONE);
+            emptyView.setVisibility(View.VISIBLE);
+        } else {
+            recyclerView.setVisibility(View.VISIBLE);
+            emptyView.setVisibility(View.GONE);
+        }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (resultCode == Activity.RESULT_OK) {
+            if (requestCode == REQUEST_CODE_ADD_TAG || requestCode == REQUEST_CODE_EDIT_TAG) {
+                // loadFormattingTags(); // Implicitly called by onResume, but can be explicit if needed
+            }
+        }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    // onDestroy is not strictly required here as FormattingTagManager is opened/closed per operation
+    // in both the adapter and loadFormattingTags. If tagManager were kept open for the activity's
+    // lifecycle, then closing it in onDestroy would be crucial.
+}

--- a/app/src/main/res/layout/activity_edit_formatting_tag.xml
+++ b/app/src/main/res/layout/activity_edit_formatting_tag.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".formattingtags.EditFormattingTagActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar_edit_formatting_tag"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:padding="16dp"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/edit_tag_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/formatting_tag_name_hint"
+                android:inputType="textCapWords" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/edit_tag_opening_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/formatting_tag_opening_text_hint"
+                android:inputType="textNoSuggestions" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/edit_tag_closing_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/formatting_tag_closing_text_hint"
+                android:inputType="textNoSuggestions" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/edit_tag_keystroke_sequence"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/formatting_tag_keystrokes_hint"
+                android:inputType="textNoSuggestions" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <Button
+            android:id="@+id/button_save_formatting_tag"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/save_button_text"
+            android:backgroundTint="?attr/colorPrimary"
+            android:textColor="?attr/colorOnPrimary"/>
+
+    </LinearLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_formatting_tags.xml
+++ b/app/src/main/res/layout/activity_formatting_tags.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".formattingtags.FormattingTagsActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar_formatting_tags"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/formatting_tags_recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        android:padding="8dp"
+        android:clipToPadding="false"/>
+
+    <TextView
+        android:id="@+id/empty_formatting_tags_text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/empty_formatting_tags_text"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:visibility="gone" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab_add_formatting_tag"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="16dp"
+        android:src="@drawable/ic_add"
+        app:tint="@android:color/white"
+        android:contentDescription="@string/content_description_add_new_formatting_tag" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/list_item_formatting_tag.xml
+++ b/app/src/main/res/layout/list_item_formatting_tag.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="12dp"
+    android:gravity="center_vertical"
+    android:background="?android:attr/selectableItemBackground">
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/tag_name_text_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceListItem"
+            android:textStyle="bold"
+            android:text="Tag Name" />
+
+        <TextView
+            android:id="@+id/tag_opening_text_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="?android:attr/textColorSecondary"
+            android:layout_marginTop="2dp"
+            android:text="<tag>" />
+            
+        <TextView
+            android:id="@+id/tag_keystrokes_text_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="?android:attr/textColorTertiary"
+            android:layout_marginTop="2dp"
+            android:text="CTRL+K" />
+
+    </LinearLayout>
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/tag_active_switch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"/>
+
+    <ImageButton
+        android:id="@+id/tag_edit_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/content_description_edit_formatting_tag"
+        android:padding="8dp"
+        android:src="@drawable/ic_menu_edit" />
+
+    <ImageButton
+        android:id="@+id/tag_delete_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/content_description_delete_formatting_tag"
+        android:padding="8dp"
+        android:src="@drawable/ic_menu_delete" />
+
+</LinearLayout>

--- a/app/src/main/res/menu/menu_drawer.xml
+++ b/app/src/main/res/menu/menu_drawer.xml
@@ -24,5 +24,9 @@
             android:id="@+id/nav_macros"
             android:icon="@android:drawable/ic_menu_manage"
             android:title="Macros" />
+        <item
+            android:id="@+id/nav_formatting_tags"
+            android:icon="@android:drawable/ic_menu_label"
+            android:title="@string/formatting_tags_activity_title" />
     </group>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,4 +72,23 @@
     <string name="prompt_deleted_message">Prompt deleted.</string>
     <string name="prompt_not_found_message">Prompt not found.</string>
 
+    <!-- Formatting Tags Feature -->
+    <string name="formatting_tags_activity_title">Formatting Tags</string>
+    <string name="add_new_formatting_tag_title">Add Formatting Tag</string>
+    <string name="edit_formatting_tag_title">Edit Formatting Tag</string>
+    <string name="empty_formatting_tags_text">No formatting tags defined. Tap the \'+\' button to add one.</string>
+    <string name="content_description_add_new_formatting_tag">Add new formatting tag</string>
+    <string name="formatting_tag_name_hint">Tag Name (e.g., Bold)</string>
+    <string name="formatting_tag_opening_text_hint">Opening Tag (e.g., &lt;b&gt;)</string>
+    <string name="formatting_tag_closing_text_hint">Closing Tag (e.g., &lt;/b&gt;)</string>
+    <string name="formatting_tag_keystrokes_hint">Keystrokes (e.g., CTRL_LEFT+KEY_B)</string>
+    <string name="formatting_tag_label_active">Active</string>
+    <string name="content_description_edit_formatting_tag">Edit formatting tag</string>
+    <string name="content_description_delete_formatting_tag">Delete formatting tag</string>
+    <string name="formatting_tag_deleted_message">Formatting tag deleted</string>
+    <string name="formatting_tag_saved_message">Formatting tag saved</string>
+    <string name="tag_name_required_message">Tag name is required.</string>
+    <string name="opening_tag_text_required_message">Opening tag text is required.</string>
+    <string name="keystroke_sequence_required_message">Keystroke sequence is required.</string>
+    <string name="untitled_formatting_tag_label">Untitled Tag</string>
 </resources>


### PR DESCRIPTION
This commit introduces a comprehensive feature allowing you to define, manage, and use custom formatting tags for InputStick text output.

Key components and changes:

1.  **Data Layer (`com.drgraff.speakkey.formattingtags` package):**
    *   `FormattingTag.java`: Data model for a formatting tag, including
        ID, name, opening tag text (e.g., "<mybold>"), closing tag text
        (e.g., "</mybold>"), keystroke sequence (e.g., "CTRL_LEFT+KEY_B"),
        and an active status.
    *   `FormattingTagDbHelper.java`: SQLiteOpenHelper implementation for
        creating and managing the `formatting_tags` database table.
        The table includes a UNIQUE constraint on `opening_tag_text`.
    *   `FormattingTagManager.java`: Provides CRUD (Create, Read, Update,
        Delete) operations for formatting tags, interacting with the
        SQLite database. Includes a method to get all active tags,
        ordered by opening tag length (desc) then name (asc).

2.  **Formatting Tags List UI:**
    *   `FormattingTagsActivity.java`: Displays a list of all defined
        formatting tags using a RecyclerView.
    *   `activity_formatting_tags.xml`: Layout for the list activity,
        including a Toolbar, RecyclerView, empty state TextView, and a
        FloatingActionButton to add new tags.
    *   `FormattingTagAdapter.java`: Adapter for the RecyclerView,
        displaying each tag's name, opening text, keystrokes, an
        activate/deactivate switch, an edit button, and a delete button.
        Handles your interactions for these elements.
    *   `list_item_formatting_tag.xml`: Layout for individual items in the
        tag list.

3.  **Add/Edit Formatting Tag UI:**
    *   `EditFormattingTagActivity.java`: Allows you to create a new
        formatting tag or modify an existing one.
    *   `activity_edit_formatting_tag.xml`: Layout for the editor, with
        input fields for tag name, opening tag text, closing tag text,
        and keystroke sequence. Includes input validation.

4.  **Navigation Drawer Integration:**
    *   Added "FormattingTags" item to `menu_drawer.xml`.
    *   Updated `MainActivity.java` to navigate to
        `FormattingTagsActivity` when the item is selected.

5.  **`TextTagFormatter.java` Refactoring:**
    *   Removed previous logic for hardcoded `<b>`/`<i>` tags and the
        single SharedPreferences-based custom tag.
    *   Now fetches all active `FormattingTag` objects from
        `FormattingTagManager`.
    *   The `formatAndSend` method iterates through these active tags,
        matching their `openingTagText` and `closingTagText` in the
        input text and applying the defined `keystrokeSequence` using
        the existing `sendCustomKeystrokes` method.

6.  **String Resources:**
    *   Added necessary string resources for titles, hints, content
        descriptions, and messages related to this feature for you.

7.  **Build Fix (related to previous work):**
    *   Corrected mapping for `KEY_PASUE` / `KEY_PAUSE` in
        `TextTagFormatter.getHidKeyCode` to resolve a build error from
        an earlier commit.

This feature provides a flexible and user-configurable system for text formatting macros via InputStick.