### PR TITLE
fix: Correct XML character escaping in list_item_formatting_tag.xml

### DIFF
--- a/app/src/main/res/layout/list_item_formatting_tag.xml
+++ b/app/src/main/res/layout/list_item_formatting_tag.xml
@@ -28,7 +28,7 @@
             android:textAppearance="?android:attr/textAppearanceSmall"
             android:textColor="?android:attr/textColorSecondary"
             android:layout_marginTop="2dp"
-            android:text="<tag>" />
+            android:text="&lt;tag&gt;" />
             
         <TextView
             android:id="@+id/tag_keystrokes_text_view"


### PR DESCRIPTION
Resolves a build failure (Task :app:packageDebugResources FAILED) caused by an unescaped '<' character in an android:text attribute within app/src/main/res/layout/list_item_formatting_tag.xml.

The android:text attribute for the TextView with id tag_opening_text_view was changed from "<tag>" to "&lt;tag&gt;" to ensure correct XML parsing.