### PR TITLE
fix: Declare FormattingTagsActivity and EditFormattingTagActivity in …

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,6 +57,19 @@
             android:parentActivityName=".data.PromptsActivity" />
 
         <activity
+            android:name=".formattingtags.FormattingTagsActivity"
+            android:exported="false"
+            android:label="@string/formatting_tags_activity_title"
+            android:theme="@style/Theme.SpeakKey.NoActionBar"
+            android:parentActivityName=".MainActivity" />
+        <activity
+            android:name=".formattingtags.EditFormattingTagActivity"
+            android:exported="false"
+            android:label="@string/edit_formatting_tag_title"
+            android:theme="@style/Theme.SpeakKey.NoActionBar"
+            android:parentActivityName=".formattingtags.FormattingTagsActivity" />
+
+        <activity
             android:name="com.speakkey.ui.macros.MacroListActivity"
             android:label="Manage Macros"
             android:theme="@style/Theme.SpeakKey.NoActionBar" />


### PR DESCRIPTION
…AndroidManifest

Resolves an ActivityNotFoundException that occurred when trying to navigate to the Formatting Tags feature.

The following activities were added to AndroidManifest.xml:
- .formattingtags.FormattingTagsActivity
- .formattingtags.EditFormattingTagActivity

These declarations include appropriate labels, themes, parent activity names, and set android:exported="false".