### PR TITLE
feat: Refine Formatting Tags UX and Fix Edit Bug

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/formattingtags/EditFormattingTagActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/formattingtags/EditFormattingTagActivity.java
@@ -3,11 +3,20 @@ package com.drgraff.speakkey.formattingtags;
 import android.app.Activity;
 import android.os.Bundle;
 import android.view.MenuItem;
+import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.CheckBox;
 import android.widget.EditText;
+import android.widget.Spinner;
+import android.widget.TextView; // Added for Spinner error
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import java.util.ArrayList; // Added
+import java.util.Arrays; // Added
+import java.util.List; // Added
+import java.util.Map; // Added
+import java.util.LinkedHashMap; // Added To maintain insertion order for Spinner
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
@@ -20,11 +29,31 @@ public class EditFormattingTagActivity extends AppCompatActivity {
     public static final String EXTRA_TAG_ID = "com.drgraff.speakkey.EXTRA_TAG_ID";
     private static final long INVALID_TAG_ID = -1;
 
-    private TextInputEditText editTextName, editTextOpeningTag, editTextClosingTag, editTextKeystrokeSequence;
+    private TextInputEditText editTextName, editTextOpeningTag; // editTextKeystrokeSequence removed
+    private CheckBox checkBoxCtrl, checkBoxAlt, checkBoxShift, checkBoxMeta; // Added
+    private Spinner spinnerMainKey; // Added
+    private List<KeystrokeDisplay> keySpinnerItems; // Added For Spinner data
     private Button buttonSave;
     private FormattingTagManager tagManager;
     private FormattingTag currentTag;
     private long currentTagId = INVALID_TAG_ID;
+
+    // Simple class to hold display name and actual key value for the Spinner
+    static class KeystrokeDisplay {
+        public String displayName;
+        public String keyValue; // e.g., "KEY_A", "KEY_ENTER"
+
+        public KeystrokeDisplay(String displayName, String keyValue) {
+            this.displayName = displayName;
+            this.keyValue = keyValue;
+        }
+
+        @NonNull
+        @Override
+        public String toString() {
+            return displayName; // This is what will be shown in the Spinner
+        }
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -40,9 +69,17 @@ public class EditFormattingTagActivity extends AppCompatActivity {
 
         editTextName = findViewById(R.id.edit_tag_name);
         editTextOpeningTag = findViewById(R.id.edit_tag_opening_text);
-        editTextClosingTag = findViewById(R.id.edit_tag_closing_text);
-        editTextKeystrokeSequence = findViewById(R.id.edit_tag_keystroke_sequence);
+        // editTextKeystrokeSequence = findViewById(R.id.edit_tag_keystroke_sequence); // Removed
+
+        checkBoxCtrl = findViewById(R.id.checkbox_modifier_ctrl); // Added
+        checkBoxAlt = findViewById(R.id.checkbox_modifier_alt); // Added
+        checkBoxShift = findViewById(R.id.checkbox_modifier_shift); // Added
+        checkBoxMeta = findViewById(R.id.checkbox_modifier_meta); // Added
+        spinnerMainKey = findViewById(R.id.spinner_main_key); // Added
+
         buttonSave = findViewById(R.id.button_save_formatting_tag);
+
+        populateMainKeySpinner(); // Added call
 
         tagManager = new FormattingTagManager(this);
         tagManager.open();
@@ -54,22 +91,24 @@ public class EditFormattingTagActivity extends AppCompatActivity {
             if (currentTag != null) {
                 editTextName.setText(currentTag.getName());
                 editTextOpeningTag.setText(currentTag.getOpeningTagText());
-                editTextClosingTag.setText(currentTag.getClosingTagText());
-                editTextKeystrokeSequence.setText(currentTag.getKeystrokeSequence());
+                // editTextKeystrokeSequence.setText(currentTag.getKeystrokeSequence()); // Removed
+                parseAndSetKeystrokeUI(currentTag.getKeystrokeSequence()); // Added call
+                // Ensure Activity title is also set for editing here
                 if (getSupportActionBar() != null) {
-                    getSupportActionBar().setTitle(getString(R.string.edit_formatting_tag_title));
+                    getSupportActionBar().setTitle(R.string.edit_formatting_tag_title);
                 }
             } else {
-                Toast.makeText(this, "Error: Formatting tag not found.", Toast.LENGTH_LONG).show();
+                // Handle case where tag with ID is not found (current logic seems to Toast and set title to Add)
+                // This part of the existing logic can remain.
+                Toast.makeText(this, "Formatting Tag not found, creating a new one.", Toast.LENGTH_SHORT).show();
                 if (getSupportActionBar() != null) {
-                    getSupportActionBar().setTitle(getString(R.string.add_new_formatting_tag_title));
+                    getSupportActionBar().setTitle(R.string.add_new_formatting_tag_title);
                 }
-                // Treat as new if tag not found, currentTagId remains invalid for save logic
-                currentTagId = INVALID_TAG_ID;
+                currentTagId = INVALID_TAG_ID; // Reset to ensure it behaves as 'add new'
             }
         } else {
             if (getSupportActionBar() != null) {
-                getSupportActionBar().setTitle(getString(R.string.add_new_formatting_tag_title));
+                getSupportActionBar().setTitle(R.string.add_new_formatting_tag_title);
             }
         }
 
@@ -79,8 +118,45 @@ public class EditFormattingTagActivity extends AppCompatActivity {
     private void saveFormattingTag() {
         String name = editTextName.getText().toString().trim();
         String openingText = editTextOpeningTag.getText().toString().trim();
-        String closingText = editTextClosingTag.getText().toString().trim(); // Can be empty
-        String keystrokes = editTextKeystrokeSequence.getText().toString().trim();
+        // String keystrokes = editTextKeystrokeSequence.getText().toString().trim(); // Removed
+
+        // Construct Keystroke String from New UI
+        StringBuilder keystrokesBuilder = new StringBuilder();
+        if (checkBoxCtrl.isChecked()) {
+            keystrokesBuilder.append("CTRL_LEFT+");
+        }
+        if (checkBoxAlt.isChecked()) {
+            keystrokesBuilder.append("ALT_LEFT+");
+        }
+        if (checkBoxShift.isChecked()) {
+            keystrokesBuilder.append("SHIFT_LEFT+");
+        }
+        if (checkBoxMeta.isChecked()) {
+            keystrokesBuilder.append("GUI_LEFT+");
+        }
+
+        KeystrokeDisplay selectedKeyItem = (KeystrokeDisplay) spinnerMainKey.getSelectedItem();
+        String mainKeyValue = "";
+        if (selectedKeyItem != null && selectedKeyItem.keyValue != null && !selectedKeyItem.keyValue.isEmpty()) {
+            mainKeyValue = selectedKeyItem.keyValue;
+            keystrokesBuilder.append(mainKeyValue);
+        } else if (keystrokesBuilder.length() > 0) {
+            // Modifiers selected but no main key: remove trailing '+'
+             keystrokesBuilder.setLength(keystrokesBuilder.length() - 1);
+        }
+
+        String keystrokes = keystrokesBuilder.toString();
+        // New Validation for keystrokes (main key must be selected)
+        if (mainKeyValue.isEmpty()) {
+            Toast.makeText(this, "Main key must be selected.", Toast.LENGTH_SHORT).show();
+            // Optionally, set an error on the spinner (not straightforward) or a general Toast.
+            // ((TextView)spinnerMainKey.getSelectedView()).setError("Main key required"); // This might not work well or look good
+            if (spinnerMainKey.getSelectedView() instanceof TextView) {
+                 ((TextView)spinnerMainKey.getSelectedView()).setError("Main key required");
+            }
+            return;
+        }
+        // End of new keystroke construction and validation
 
         if (name.isEmpty()) {
             editTextName.setError(getString(R.string.tag_name_required_message));
@@ -96,25 +172,20 @@ public class EditFormattingTagActivity extends AppCompatActivity {
             return;
         }
 
-        if (keystrokes.isEmpty()) {
-            editTextKeystrokeSequence.setError(getString(R.string.keystroke_sequence_required_message));
-            editTextKeystrokeSequence.requestFocus();
-            Toast.makeText(this, getString(R.string.keystroke_sequence_required_message), Toast.LENGTH_SHORT).show();
-            return;
-        }
+        // Old keystrokes.isEmpty() validation removed
 
         if (currentTagId != INVALID_TAG_ID && currentTag != null) {
             // Editing existing tag
             currentTag.setName(name);
             currentTag.setOpeningTagText(openingText);
-            currentTag.setClosingTagText(closingText);
+            // currentTag.setClosingTagText(closingText); // Removed
             currentTag.setKeystrokeSequence(keystrokes);
             // currentTag.setActive(true); // Assuming active, or add a switch
             tagManager.updateTag(currentTag);
         } else {
             // Adding new tag
             // ID 0 is fine as SQLite will auto-increment. isActive defaults to true in DB.
-            FormattingTag newTag = new FormattingTag(0, name, openingText, closingText, keystrokes, true);
+            FormattingTag newTag = new FormattingTag(0, name, openingText, keystrokes, true); // Removed closingText
             tagManager.addTag(newTag);
         }
 
@@ -137,6 +208,111 @@ public class EditFormattingTagActivity extends AppCompatActivity {
         super.onDestroy();
         if (tagManager != null) {
             tagManager.close();
+        }
+    }
+
+    private void populateMainKeySpinner() {
+        keySpinnerItems = new ArrayList<>();
+        // Add a "None" or "Select Key..." option as the first item
+        keySpinnerItems.add(new KeystrokeDisplay(getString(R.string.prompt_select_key), "")); // Empty value for no key
+
+        // --- Populate with actual keys (This list should be comprehensive) ---
+        // Example:
+        keySpinnerItems.add(new KeystrokeDisplay("Enter", "KEY_ENTER"));
+        keySpinnerItems.add(new KeystrokeDisplay("Tab", "KEY_TAB"));
+        keySpinnerItems.add(new KeystrokeDisplay("Space", "KEY_SPACEBAR"));
+        keySpinnerItems.add(new KeystrokeDisplay("Backspace", "KEY_BACKSPACE"));
+        keySpinnerItems.add(new KeystrokeDisplay("Esc", "KEY_ESCAPE"));
+        keySpinnerItems.add(new KeystrokeDisplay("Delete", "KEY_DELETE"));
+        keySpinnerItems.add(new KeystrokeDisplay("Insert", "KEY_INSERT"));
+        keySpinnerItems.add(new KeystrokeDisplay("Home", "KEY_HOME"));
+        keySpinnerItems.add(new KeystrokeDisplay("End", "KEY_END"));
+        keySpinnerItems.add(new KeystrokeDisplay("Page Up", "KEY_PAGE_UP"));
+        keySpinnerItems.add(new KeystrokeDisplay("Page Down", "KEY_PAGE_DOWN"));
+        keySpinnerItems.add(new KeystrokeDisplay("Up Arrow", "KEY_ARROW_UP"));
+        keySpinnerItems.add(new KeystrokeDisplay("Down Arrow", "KEY_ARROW_DOWN"));
+        keySpinnerItems.add(new KeystrokeDisplay("Left Arrow", "KEY_ARROW_LEFT"));
+        keySpinnerItems.add(new KeystrokeDisplay("Right Arrow", "KEY_ARROW_RIGHT"));
+
+        for (char c = 'A'; c <= 'Z'; c++) {
+            keySpinnerItems.add(new KeystrokeDisplay(String.valueOf(c), "KEY_" + c));
+        }
+        for (char c = '0'; c <= '9'; c++) {
+            keySpinnerItems.add(new KeystrokeDisplay(String.valueOf(c), "KEY_" + c));
+        }
+        for (int i = 1; i <= 12; i++) {
+            keySpinnerItems.add(new KeystrokeDisplay("F" + i, "KEY_F" + i));
+        }
+        // Add other keys as defined in TextTagFormatter.getHidKeyCode's switch cases
+        keySpinnerItems.add(new KeystrokeDisplay("- (Minus)", "KEY_MINUS"));
+        keySpinnerItems.add(new KeystrokeDisplay("= (Equals)", "KEY_EQUALS"));
+        keySpinnerItems.add(new KeystrokeDisplay("[ (Left Bracket)", "KEY_LEFT_BRACKET"));
+        keySpinnerItems.add(new KeystrokeDisplay("] (Right Bracket)", "KEY_RIGHT_BRACKET"));
+        keySpinnerItems.add(new KeystrokeDisplay("\\ (Backslash)", "KEY_BACKSLASH"));
+        keySpinnerItems.add(new KeystrokeDisplay("; (Semicolon)", "KEY_SEMICOLON"));
+        keySpinnerItems.add(new KeystrokeDisplay("' (Apostrophe)", "KEY_APOSTROPHE"));
+        keySpinnerItems.add(new KeystrokeDisplay("` (Grave Accent)", "KEY_GRAVE"));
+        keySpinnerItems.add(new KeystrokeDisplay(", (Comma)", "KEY_COMA"));
+        keySpinnerItems.add(new KeystrokeDisplay(". (Period)", "KEY_DOT"));
+        keySpinnerItems.add(new KeystrokeDisplay("/ (Slash)", "KEY_SLASH"));
+        keySpinnerItems.add(new KeystrokeDisplay("Caps Lock", "KEY_CAPS_LOCK"));
+        keySpinnerItems.add(new KeystrokeDisplay("Print Screen", "KEY_PRINT_SCREEN"));
+        keySpinnerItems.add(new KeystrokeDisplay("Scroll Lock", "KEY_SCROLL_LOCK"));
+        keySpinnerItems.add(new KeystrokeDisplay("Pause", "KEY_PAUSE")); // Or KEY_PASUE if that's the actual constant
+        keySpinnerItems.add(new KeystrokeDisplay("Application", "KEY_APPLICATION"));
+        // Numpad keys
+        keySpinnerItems.add(new KeystrokeDisplay("Num Lock", "KEY_NUM_LOCK"));
+        keySpinnerItems.add(new KeystrokeDisplay("Num /", "KEY_NUM_SLASH"));
+        keySpinnerItems.add(new KeystrokeDisplay("Num *", "KEY_NUM_STAR"));
+        keySpinnerItems.add(new KeystrokeDisplay("Num -", "KEY_NUM_MINUS"));
+        keySpinnerItems.add(new KeystrokeDisplay("Num +", "KEY_NUM_PLUS"));
+        keySpinnerItems.add(new KeystrokeDisplay("Num Enter", "KEY_NUM_ENTER"));
+        for (int i = 0; i <= 9; i++) {
+             keySpinnerItems.add(new KeystrokeDisplay("Num " + i, "KEY_NUM_" + i));
+        }
+        keySpinnerItems.add(new KeystrokeDisplay("Num . (Dot)", "KEY_NUM_DOT"));
+
+
+        ArrayAdapter<KeystrokeDisplay> adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_dropdown_item, keySpinnerItems);
+        spinnerMainKey.setAdapter(adapter);
+    }
+
+    private void parseAndSetKeystrokeUI(String keystrokeSequence) {
+        if (keystrokeSequence == null || keystrokeSequence.isEmpty()) {
+            return;
+        }
+        // Reset UI elements first
+        checkBoxCtrl.setChecked(false);
+        checkBoxAlt.setChecked(false);
+        checkBoxShift.setChecked(false);
+        checkBoxMeta.setChecked(false);
+        spinnerMainKey.setSelection(0); // Default to "Select Key..."
+
+        String[] parts = keystrokeSequence.split("\\+"); // Use "\\+" to split by literal '+'
+        String mainKeyPart = null;
+
+        for (String part : parts) {
+            part = part.trim().toUpperCase(); // Match TextTagFormatter.getHidKeyCode logic
+            if (part.equals("CTRL_LEFT") || part.equals("CTRL_RIGHT") || part.equals("CTRL")) {
+                checkBoxCtrl.setChecked(true);
+            } else if (part.equals("ALT_LEFT") || part.equals("ALT_RIGHT") || part.equals("ALT")) {
+                checkBoxAlt.setChecked(true);
+            } else if (part.equals("SHIFT_LEFT") || part.equals("SHIFT_RIGHT") || part.equals("SHIFT")) {
+                checkBoxShift.setChecked(true);
+            } else if (part.equals("GUI_LEFT") || part.equals("GUI_RIGHT") || part.equals("META")) {
+                checkBoxMeta.setChecked(true);
+            } else {
+                mainKeyPart = part; 
+            }
+        }
+
+        if (mainKeyPart != null) {
+            for (int i = 0; i < keySpinnerItems.size(); i++) {
+                if (keySpinnerItems.get(i).keyValue.equalsIgnoreCase(mainKeyPart)) {
+                    spinnerMainKey.setSelection(i);
+                    break;
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTag.java
+++ b/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTag.java
@@ -7,7 +7,7 @@ public class FormattingTag {
     private long id;
     private String name;
     private String openingTagText;
-    private String closingTagText;
+    // private String closingTagText; // Removed
     private String keystrokeSequence;
     private boolean isActive;
 
@@ -16,20 +16,20 @@ public class FormattingTag {
     }
 
     // Constructor for all fields (id can be set later or auto-generated)
-    public FormattingTag(String name, String openingTagText, String closingTagText, String keystrokeSequence, boolean isActive) {
+    public FormattingTag(String name, String openingTagText, String keystrokeSequence, boolean isActive) {
         this.name = name;
         this.openingTagText = openingTagText;
-        this.closingTagText = closingTagText;
+        // this.closingTagText = closingTagText; // Removed
         this.keystrokeSequence = keystrokeSequence;
         this.isActive = isActive;
     }
 
     // Constructor including id
-    public FormattingTag(long id, String name, String openingTagText, String closingTagText, String keystrokeSequence, boolean isActive) {
+    public FormattingTag(long id, String name, String openingTagText, String keystrokeSequence, boolean isActive) {
         this.id = id;
         this.name = name;
         this.openingTagText = openingTagText;
-        this.closingTagText = closingTagText;
+        // this.closingTagText = closingTagText; // Removed
         this.keystrokeSequence = keystrokeSequence;
         this.isActive = isActive;
     }
@@ -59,13 +59,13 @@ public class FormattingTag {
         this.openingTagText = openingTagText;
     }
 
-    public String getClosingTagText() {
-        return closingTagText;
-    }
+    // public String getClosingTagText() { // Removed
+    // return closingTagText;
+    // }
 
-    public void setClosingTagText(String closingTagText) {
-        this.closingTagText = closingTagText;
-    }
+    // public void setClosingTagText(String closingTagText) { // Removed
+    // this.closingTagText = closingTagText;
+    // }
 
     public String getKeystrokeSequence() {
         return keystrokeSequence;
@@ -102,7 +102,7 @@ public class FormattingTag {
                 "id=" + id +
                 ", name='" + name + '\'' +
                 ", openingTagText='" + openingTagText + '\'' +
-                ", closingTagText='" + closingTagText + '\'' +
+                // ", closingTagText='" + closingTagText + '\'' + // Removed
                 ", keystrokeSequence='" + keystrokeSequence + '\'' +
                 ", isActive=" + isActive +
                 '}';

--- a/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTagAdapter.java
+++ b/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTagAdapter.java
@@ -13,8 +13,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import com.drgraff.speakkey.R;
-// Import EditFormattingTagActivity once it's created
-// import com.drgraff.speakkey.formattingtags.EditFormattingTagActivity;
+import com.drgraff.speakkey.formattingtags.EditFormattingTagActivity; // Added
 
 import java.util.List;
 
@@ -72,16 +71,20 @@ public class FormattingTagAdapter extends RecyclerView.Adapter<FormattingTagAdap
 
         holder.editButton.setOnClickListener(v -> {
             // Intent intent = new Intent(context, EditFormattingTagActivity.class);
-            // intent.putExtra(EditFormattingTagActivity.EXTRA_TAG_ID, currentTag.getId());
-            // context.startActivity(intent);
-            // For now, as EditFormattingTagActivity doesn't exist, we can log or Toast
-            Log.d(TAG, "Edit button clicked for tag ID: " + currentTag.getId());
-            Toast.makeText(context, "Edit for tag: " + currentTag.getName(), Toast.LENGTH_SHORT).show();
-            // TODO: Replace with actual Intent when EditFormattingTagActivity is available
-             if (context instanceof FormattingTagsActivity) {
-                Intent intent = new Intent(context, EditFormattingTagActivity.class); // Assuming EditFormattingTagActivity will be created
-                intent.putExtra("EXTRA_TAG_ID", currentTag.getId());
+            FormattingTag currentTag = formattingTags.get(holder.getAdapterPosition()); // Get current tag safely
+            if (currentTag == null) return; // Should not happen if list is consistent
+
+            Intent intent = new Intent(context, EditFormattingTagActivity.class);
+            intent.putExtra(EditFormattingTagActivity.EXTRA_TAG_ID, currentTag.getId());
+
+            if (context instanceof FormattingTagsActivity) {
                 ((FormattingTagsActivity) context).startActivityForResult(intent, FormattingTagsActivity.REQUEST_CODE_EDIT_TAG);
+            } else {
+                // Fallback if context is not the activity, though less ideal for startActivityForResult
+                // This might indicate a context issue if it ever happens.
+                // For now, simple startActivity, but this path should ideally not be taken.
+                context.startActivity(intent);
+                Log.w(TAG, "Starting EditFormattingTagActivity from a non-Activity context or context not equipped for result.");
             }
         });
 

--- a/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTagDbHelper.java
+++ b/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTagDbHelper.java
@@ -7,24 +7,25 @@ import android.database.sqlite.SQLiteOpenHelper;
 public class FormattingTagDbHelper extends SQLiteOpenHelper {
 
     public static final String DATABASE_NAME = "formatting_tags.db";
-    public static final int DATABASE_VERSION = 1;
+    public static final int DATABASE_VERSION = 2; // Incremented version
 
     public static final String TABLE_FORMATTING_TAGS = "formatting_tags";
     public static final String COLUMN_ID = "_id"; // Standard convention for primary key
     public static final String COLUMN_NAME = "name";
     public static final String COLUMN_OPENING_TAG_TEXT = "opening_tag_text";
-    public static final String COLUMN_CLOSING_TAG_TEXT = "closing_tag_text";
+    // public static final String COLUMN_CLOSING_TAG_TEXT = "closing_tag_text"; // Removed
     public static final String COLUMN_KEYSTROKE_SEQUENCE = "keystroke_sequence";
     public static final String COLUMN_IS_ACTIVE = "is_active";
 
-    private static final String TABLE_CREATE =
+    // Updated table creation string
+    private static final String TABLE_CREATE_V2 =
             "CREATE TABLE " + TABLE_FORMATTING_TAGS + " (" +
                     COLUMN_ID + " INTEGER PRIMARY KEY AUTOINCREMENT, " +
                     COLUMN_NAME + " TEXT NOT NULL, " +
                     COLUMN_OPENING_TAG_TEXT + " TEXT NOT NULL UNIQUE, " +
-                    COLUMN_CLOSING_TAG_TEXT + " TEXT NOT NULL, " +
+                    // COLUMN_CLOSING_TAG_TEXT + " TEXT NOT NULL, " + // Removed
                     COLUMN_KEYSTROKE_SEQUENCE + " TEXT NOT NULL, " +
-                    COLUMN_IS_ACTIVE + " INTEGER NOT NULL DEFAULT 1" + // Default to true (1)
+                    COLUMN_IS_ACTIVE + " INTEGER NOT NULL DEFAULT 1" +
                     ");";
 
     public FormattingTagDbHelper(Context context) {
@@ -33,13 +34,17 @@ public class FormattingTagDbHelper extends SQLiteOpenHelper {
 
     @Override
     public void onCreate(SQLiteDatabase db) {
-        db.execSQL(TABLE_CREATE);
+        db.execSQL(TABLE_CREATE_V2); // Use new creation string
     }
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-        // Simple upgrade policy: drop table and recreate
-        db.execSQL("DROP TABLE IF EXISTS " + TABLE_FORMATTING_TAGS);
-        onCreate(db);
+        if (oldVersion < 2) {
+            // For simplicity in this development stage, we drop and recreate.
+            // A real-world app might use ALTER TABLE to preserve data.
+            db.execSQL("DROP TABLE IF EXISTS " + TABLE_FORMATTING_TAGS);
+            onCreate(db); // Recreate with the new schema (V2)
+        }
+        // Add further migration steps for future versions if (oldVersion < 3), etc.
     }
 }

--- a/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTagManager.java
+++ b/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTagManager.java
@@ -51,7 +51,7 @@ public class FormattingTagManager {
         ContentValues values = new ContentValues();
         values.put(FormattingTagDbHelper.COLUMN_NAME, tag.getName());
         values.put(FormattingTagDbHelper.COLUMN_OPENING_TAG_TEXT, tag.getOpeningTagText());
-        values.put(FormattingTagDbHelper.COLUMN_CLOSING_TAG_TEXT, tag.getClosingTagText());
+        // values.put(FormattingTagDbHelper.COLUMN_CLOSING_TAG_TEXT, tag.getClosingTagText()); // Removed
         values.put(FormattingTagDbHelper.COLUMN_KEYSTROKE_SEQUENCE, tag.getKeystrokeSequence());
         values.put(FormattingTagDbHelper.COLUMN_IS_ACTIVE, tag.isActive() ? 1 : 0);
 
@@ -130,7 +130,7 @@ public class FormattingTagManager {
         ContentValues values = new ContentValues();
         values.put(FormattingTagDbHelper.COLUMN_NAME, tag.getName());
         values.put(FormattingTagDbHelper.COLUMN_OPENING_TAG_TEXT, tag.getOpeningTagText());
-        values.put(FormattingTagDbHelper.COLUMN_CLOSING_TAG_TEXT, tag.getClosingTagText());
+        // values.put(FormattingTagDbHelper.COLUMN_CLOSING_TAG_TEXT, tag.getClosingTagText()); // Removed
         values.put(FormattingTagDbHelper.COLUMN_KEYSTROKE_SEQUENCE, tag.getKeystrokeSequence());
         values.put(FormattingTagDbHelper.COLUMN_IS_ACTIVE, tag.isActive() ? 1 : 0);
 
@@ -167,16 +167,16 @@ public class FormattingTagManager {
         int idIndex = cursor.getColumnIndex(FormattingTagDbHelper.COLUMN_ID);
         int nameIndex = cursor.getColumnIndex(FormattingTagDbHelper.COLUMN_NAME);
         int openingTagIndex = cursor.getColumnIndex(FormattingTagDbHelper.COLUMN_OPENING_TAG_TEXT);
-        int closingTagIndex = cursor.getColumnIndex(FormattingTagDbHelper.COLUMN_CLOSING_TAG_TEXT);
+        // int closingTagIndex = cursor.getColumnIndex(FormattingTagDbHelper.COLUMN_CLOSING_TAG_TEXT); // Removed
         int keystrokeIndex = cursor.getColumnIndex(FormattingTagDbHelper.COLUMN_KEYSTROKE_SEQUENCE);
         int isActiveIndex = cursor.getColumnIndex(FormattingTagDbHelper.COLUMN_IS_ACTIVE);
 
-        if (idIndex != -1) tag.setId(cursor.getLong(idIndex));
-        if (nameIndex != -1) tag.setName(cursor.getString(nameIndex));
-        if (openingTagIndex != -1) tag.setOpeningTagText(cursor.getString(openingTagIndex));
-        if (closingTagIndex != -1) tag.setClosingTagText(cursor.getString(closingTagIndex));
-        if (keystrokeIndex != -1) tag.setKeystrokeSequence(cursor.getString(keystrokeIndex));
-        if (isActiveIndex != -1) tag.setActive(cursor.getInt(isActiveIndex) == 1);
+        tag.setId(cursor.getLong(idIndex));
+        tag.setName(cursor.getString(nameIndex));
+        tag.setOpeningTagText(cursor.getString(openingTagIndex));
+        // tag.setClosingTagText(cursor.getString(closingTagIndex)); // Removed
+        tag.setKeystrokeSequence(cursor.getString(keystrokeIndex));
+        tag.setActive(cursor.getInt(isActiveIndex) == 1);
         
         return tag;
     }

--- a/app/src/main/java/com/drgraff/speakkey/inputstick/TextTagFormatter.java
+++ b/app/src/main/java/com/drgraff/speakkey/inputstick/TextTagFormatter.java
@@ -49,7 +49,7 @@ public class TextTagFormatter {
         int i = 0;
         while (i < text.length()) {
             boolean tagFound = false;
-            if (!activeTags.isEmpty()) {
+            if (activeTags != null && !activeTags.isEmpty()) { // Added null check for activeTags
                 for (FormattingTag tag : activeTags) {
                     // Check for opening tag
                     if (tag.getOpeningTagText() != null && !tag.getOpeningTagText().isEmpty() &&
@@ -62,17 +62,7 @@ public class TextTagFormatter {
                         tagFound = true;
                         break; 
                     }
-                    // Check for closing tag
-                    if (tag.getClosingTagText() != null && !tag.getClosingTagText().isEmpty() &&
-                            text.startsWith(tag.getClosingTagText(), i)) {
-                        sendTextSegment(context, currentSegment.toString());
-                        currentSegment.setLength(0);
-                        sendCustomKeystrokes(context, tag.getKeystrokeSequence()); // Assuming keystrokes toggle
-                        applyDelay(delayMs);
-                        i += tag.getClosingTagText().length();
-                        tagFound = true;
-                        break; 
-                    }
+                    // The block for checking closingTagText has been removed.
                 }
             }
 

--- a/app/src/main/res/layout/activity_edit_formatting_tag.xml
+++ b/app/src/main/res/layout/activity_edit_formatting_tag.xml
@@ -53,34 +53,65 @@
                 android:inputType="textNoSuggestions" />
         </com.google.android.material.textfield.TextInputLayout>
 
-        <com.google.android.material.textfield.TextInputLayout
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Modifiers:"
+            android:layout_marginTop="16dp"
+            style="?android:attr/textAppearanceMedium" />
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="8dp">
+            android:orientation="horizontal"
+            android:layout_marginTop="8dp">
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/edit_tag_closing_text"
-                android:layout_width="match_parent"
+            <CheckBox
+                android:id="@+id/checkbox_modifier_ctrl"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:hint="@string/formatting_tag_closing_text_hint"
-                android:inputType="textNoSuggestions" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:text="@string/label_modifier_ctrl" />
 
-        <com.google.android.material.textfield.TextInputLayout
+            <CheckBox
+                android:id="@+id/checkbox_modifier_alt"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:text="@string/label_modifier_alt" />
+
+            <CheckBox
+                android:id="@+id/checkbox_modifier_shift"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:text="@string/label_modifier_shift" />
+
+            <CheckBox
+                android:id="@+id/checkbox_modifier_meta"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:text="@string/label_modifier_meta" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/label_main_key"
+            android:layout_marginTop="16dp"
+            style="?android:attr/textAppearanceMedium" />
+
+        <Spinner
+            android:id="@+id/spinner_main_key"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/edit_tag_keystroke_sequence"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/formatting_tag_keystrokes_hint"
-                android:inputType="textNoSuggestions" />
-        </com.google.android.material.textfield.TextInputLayout>
+            android:layout_marginTop="8dp"
+            android:prompt="@string/prompt_select_key"
+            android:spinnerMode="dropdown" />
 
         <Button
             android:id="@+id/button_save_formatting_tag"
+            android:layout_marginTop="24dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/save_button_text"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,4 +91,12 @@
     <string name="opening_tag_text_required_message">Opening tag text is required.</string>
     <string name="keystroke_sequence_required_message">Keystroke sequence is required.</string>
     <string name="untitled_formatting_tag_label">Untitled Tag</string>
+
+    <!-- Keystroke Picker for Formatting Tags -->
+    <string name="label_modifier_ctrl">Ctrl</string>
+    <string name="label_modifier_alt">Alt</string>
+    <string name="label_modifier_shift">Shift</string>
+    <string name="label_modifier_meta">Meta/Gui</string>
+    <string name="label_main_key">Main Key:</string>
+    <string name="prompt_select_key">Select Key...</string>
 </resources>


### PR DESCRIPTION
This commit introduces several improvements to the Formatting Tags feature:
1.  Fixes a bug where the Edit Formatting Tag screen was not pre-filling with the existing tag's data.
2.  Simplifies the tag structure by removing the concept of separate opening/closing tags; a single tag definition now triggers its keystroke sequence.
3.  Implements a user-friendly keystroke picker UI, replacing manual text input for keystroke sequences.

Detailed changes:

1.  **Edit Formatting Tag Bug Fix:**
    *   In `FormattingTagAdapter.java`, corrected the Intent extra key used
        when launching `EditFormattingTagActivity` to ensure the tag ID is
        passed correctly (using `EditFormattingTagActivity.EXTRA_TAG_ID`).
        This allows the edit screen to load and display the correct tag's data.

2.  **Simplified Tag Structure (Single Tag Definition):**
    *   `FormattingTag.java`: Removed `closingTagText` field and associated
        methods.
    *   `FormattingTagDbHelper.java`: Removed `COLUMN_CLOSING_TAG_TEXT` from
        the schema, incremented `DATABASE_VERSION` to 2, and updated
        `onUpgrade` to drop and recreate the table.
    *   `FormattingTagManager.java`: Updated `addTag`, `updateTag`, and
        `cursorToFormattingTag` to work without `closingTagText`.
    *   `activity_edit_formatting_tag.xml`: Removed the input field for
        "Closing Tag Text".
    *   `EditFormattingTagActivity.java`: Removed logic related to the
        closing tag `EditText`.
    *   `TextTagFormatter.java`: Modified `formatAndSend` to only recognize
        the `openingTagText` of a `FormattingTag`. The previous logic for
        checking `closingTagText` was removed.

3.  **User-Friendly Keystroke Picker UI:**
    *   `activity_edit_formatting_tag.xml`: Replaced the keystroke sequence
        `EditText` with:
        *   CheckBoxes for Ctrl, Alt, Shift, and Meta/Gui modifiers.
        *   A Spinner for selecting the main non-modifier key.
    *   `EditFormattingTagActivity.java`:
        *   Added logic to populate the main key Spinner with a comprehensive
            list of available keys (letters, numbers, function keys,
            special keys, etc.) derived from `HIDKeycodes` names.
        *   Implemented parsing of existing `keystrokeSequence` strings
            (e.g., "CTRL_LEFT+KEY_B") to set the state of the new picker UI
            when editing a tag.
        *   Implemented construction of the `keystrokeSequence` string from
            the state of the CheckBoxes and Spinner when saving a tag.
        *   Added validation to require a main key selection from the Spinner.
    *   Added new string resources for the picker UI labels.