### PR TITLE
debug: Add diagnostics to InputStickManager.typeText

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/inputstick/InputStickManager.java
+++ b/app/src/main/java/com/drgraff/speakkey/inputstick/InputStickManager.java
@@ -9,7 +9,9 @@ import androidx.preference.PreferenceManager; // Added
 import com.drgraff.speakkey.R;
 import com.inputstick.api.broadcast.InputStickBroadcast;
 import com.inputstick.api.hid.HIDKeycodes; // Added for getHidKeyCode
+import com.drgraff.speakkey.utils.AppLogManager; // Added for AppLogManager
 import java.util.List; // Added for List<InputAction>
+// Toast is already imported via android.widget.Toast
 
 public class InputStickManager {
     private static final String TAG = "InputStickManager";
@@ -44,13 +46,23 @@ public class InputStickManager {
      * @param text Text to be typed
      */
     public void typeText(String text) {
+        // 1. At the very beginning of the method
+        AppLogManager.getInstance().addEntry("INFO", TAG, "typeText() entered. Text snippet: " + (text != null && text.length() > 20 ? text.substring(0, 20) : text));
+        Toast.makeText(context, "IM.typeText() called", Toast.LENGTH_SHORT).show();
+
         if (text == null || text.isEmpty()) {
             Log.e(TAG, "Text is null or empty");
+            AppLogManager.getInstance().addEntry("WARN", TAG, "typeText() received null or empty text.");
             return;
         }
 
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
         boolean formatEnabled = sharedPreferences.getBoolean("pref_inputstick_format_tags_enabled", false);
+        
+        // 2. Immediately after reading formatEnabled preference
+        AppLogManager.getInstance().addEntry("INFO", TAG, "Preference pref_inputstick_format_tags_enabled: " + formatEnabled);
+        Toast.makeText(context, "Format Enabled Pref: " + formatEnabled, Toast.LENGTH_SHORT).show();
+
         // String delayMsStr = sharedPreferences.getString("pref_inputstick_format_delay_ms", "100"); // Removed
         // int delayMs = 100; // Removed
         // try { // Removed
@@ -60,7 +72,11 @@ public class InputStickManager {
         // } // Removed
 
         if (formatEnabled) {
-            Log.d(TAG, "InputStick text formatting is enabled.");
+            // 3. Inside the if (formatEnabled) block, just before TextTagFormatter instantiation
+            AppLogManager.getInstance().addEntry("INFO", TAG, "formatEnabled is true. Attempting to parse actions...");
+            Toast.makeText(context, "Formatting: ON - Calling parser", Toast.LENGTH_SHORT).show();
+
+            Log.d(TAG, "InputStick text formatting is enabled."); // Existing Logcat
             TextTagFormatter formatter = new TextTagFormatter();
             List<InputAction> actions = formatter.parseTextToActions(context, text);
 
@@ -85,7 +101,11 @@ public class InputStickManager {
                 }
             }
         } else {
-            Log.d(TAG, "InputStick text formatting is disabled. Sending raw text.");
+            // 4. Inside the else block (when formatEnabled is false), at the beginning
+            AppLogManager.getInstance().addEntry("INFO", TAG, "formatEnabled is false. Sending raw text.");
+            Toast.makeText(context, "Formatting: OFF - Raw text", Toast.LENGTH_SHORT).show();
+
+            Log.d(TAG, "InputStick text formatting is disabled. Sending raw text."); // Existing Logcat
             InputStickBroadcast.type(context, text, "en-US");
         }
     }


### PR DESCRIPTION
To investigate why formatting tags might not be processed, this commit adds Toast messages and Application Log entries directly within the `InputStickManager.typeText()` method.

This logging will help determine:
- If `typeText()` is being called as expected.
- The value of the 'pref_inputstick_format_tags_enabled' preference at the time of execution.
- Which processing path (formatting or raw text) is taken.

This will provide crucial information for understanding the control flow when text is sent to the InputStick.