### PR TITLE
fix: Move InputStick operations to a background thread

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/inputstick/TextTagFormatter.java
+++ b/app/src/main/java/com/drgraff/speakkey/inputstick/TextTagFormatter.java
@@ -2,7 +2,7 @@ package com.drgraff.speakkey.inputstick;
 
 import android.content.Context;
 import android.util.Log;
-import android.widget.Toast; // Added for Toast messages
+// import android.widget.Toast; // Removed Toast import
 import com.drgraff.speakkey.utils.AppLogManager; // Added for AppLogManager
 // Removed: com.inputstick.api.broadcast.InputStickBroadcast;
 // Removed: com.inputstick.api.hid.HIDKeycodes;
@@ -38,21 +38,21 @@ public class TextTagFormatter {
             tagManager.open();
             activeTags = tagManager.getActiveTags();
             
-            // Added Toast and AppLogManager entries for active tags
+            // AppLogManager entries for active tags (Toast removed)
             int activeTagCount = (activeTags != null ? activeTags.size() : 0);
-            Toast.makeText(context, "Active Tags Found: " + activeTagCount, Toast.LENGTH_LONG).show();
+            // Toast.makeText(context, "Active Tags Found: " + activeTagCount, Toast.LENGTH_LONG).show(); // Removed
             AppLogManager.getInstance().addEntry("INFO", TAG + " - Active Tags", "Number of active tags found: " + activeTagCount);
             if (activeTags != null) {
-                for (FormattingTag tagDetail : activeTags) { // Renamed 'tag' to 'tagDetail' to avoid conflict with outer scope if any
+                for (FormattingTag tagDetail : activeTags) {
                     AppLogManager.getInstance().addEntry("INFO", TAG + " - Tag Detail", "Name='" + tagDetail.getName() + "', OpeningText='" + tagDetail.getOpeningTagText() + "', Keystrokes='" + tagDetail.getKeystrokeSequence() + "'");
                 }
             }
 
         } catch (Exception e) {
             Log.e(TAG, "Error opening FormattingTagManager or getting active tags, creating TypeTextAction for whole text.", e);
-            // Added Toast and AppLogManager entries for error
+            // AppLogManager entry for error (Toast removed)
             AppLogManager.getInstance().addEntry("ERROR", TAG + " - Tag Loading Error", "Error loading formatting tags: " + e.getMessage() + (e.getCause() != null ? " - Cause: " + e.getCause().toString() : ""));
-            Toast.makeText(context, "Error loading formatting tags. Check App Log.", Toast.LENGTH_LONG).show();
+            // Toast.makeText(context, "Error loading formatting tags. Check App Log.", Toast.LENGTH_LONG).show(); // Removed
             // If DB ops fail, treat the whole text as a single segment to type
             if (text != null && !text.isEmpty()) {
                 actions.add(new TypeTextAction(text));


### PR DESCRIPTION
To address issues with skipped frames and potentially dropped commands when processing formatting tags, this commit refactors InputStickManager.typeText() to perform its core action loop (parsing text, sending keystrokes, typing text, and applying delays) on a dedicated single background thread.

This prevents blocking the main UI thread, improving app responsiveness and ensuring more reliable execution of the command sequence sent to the InputStick device.

Diagnostic Toasts originating from the background operations were removed, with reliance now on AppLogManager and Logcat for these details.