### PR TITLE
Fix: Standardize Toolbar colors for consistency

### DIFF
--- a/app/src/main/res/layout/activity_formatting_tags.xml
+++ b/app/src/main/res/layout/activity_formatting_tags.xml
@@ -16,6 +16,8 @@
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
+    app:titleTextColor="@color/textPrimary"
+    app:navigationIconTint="@color/textPrimary"
             app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/activity_macros.xml
+++ b/app/src/main/res/layout/activity_macros.xml
@@ -15,7 +15,9 @@
             android:id="@+id/toolbar_macros"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
-            android:background="@android:color/black"
+    android:background="?attr/colorPrimary"
+    app:titleTextColor="@color/textPrimary"
+    app:navigationIconTint="@color/textPrimary"
             app:popupTheme="@style/Theme.SpeakKey.PopupOverlay" />
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/activity_prompts.xml
+++ b/app/src/main/res/layout/activity_prompts.xml
@@ -16,6 +16,8 @@
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
+    app:titleTextColor="@color/textPrimary"
+    app:navigationIconTint="@color/textPrimary"
             app:popupTheme="@style/Theme.SpeakKey.PopupOverlay" />
 
     </com.google.android.material.appbar.AppBarLayout>


### PR DESCRIPTION
This commit updates the Toolbars in Prompts, Formatting Tags, and Macros activities to match the styling of the Settings activity's action bar.

Previously, these activities used a NoActionBar theme with a custom Toolbar. While their Toolbar backgrounds were generally set to `?attr/colorPrimary`, the title text and navigation icon (back arrow) colors were not explicitly defined to match `colorOnPrimary` (i.e., `@color/textPrimary` - white) from the main application theme used by SettingsActivity. Additionally, the Macros activity Toolbar had an incorrect background color.

Changes made:
- In `res/layout/activity_prompts.xml`:
    - Set `app:titleTextColor="@color/textPrimary"` on the Toolbar.
    - Set `app:navigationIconTint="@color/textPrimary"` on the Toolbar.
- In `res/layout/activity_formatting_tags.xml`:
    - Set `app:titleTextColor="@color/textPrimary"` on the Toolbar.
    - Set `app:navigationIconTint="@color/textPrimary"` on the Toolbar.
- In `res/layout/activity_macros.xml`:
    - Set `app:titleTextColor="@color/textPrimary"` on the Toolbar.
    - Set `app:navigationIconTint="@color/textPrimary"` on the Toolbar.
    - Corrected `android:background` from `@android:color/black` to `?attr/colorPrimary`.

These changes ensure a consistent look and feel for the title bar (Toolbar) background, title text, and back button arrow across these screens, aligning them with the Settings screen.

You should visually verify the changes on these screens to ensure they meet expectations.