### PR TITLE
Fix: Adapt Toolbar colors for Dark Mode consistency

### DIFF
--- a/app/src/main/res/layout/activity_formatting_tags.xml
+++ b/app/src/main/res/layout/activity_formatting_tags.xml
@@ -15,9 +15,9 @@
             android:id="@+id/toolbar_formatting_tags"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
-            android:background="?attr/colorPrimary"
+    android:background="@color/custom_toolbar_background"
     app:titleTextColor="@color/textPrimary"
-    app:navigationIconTint="@color/textPrimary"
+    app:navigationIconTint="@color/custom_toolbar_icon_tint"
             app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/activity_macros.xml
+++ b/app/src/main/res/layout/activity_macros.xml
@@ -15,9 +15,9 @@
             android:id="@+id/toolbar_macros"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
-    android:background="?attr/colorPrimary"
+    android:background="@color/custom_toolbar_background"
     app:titleTextColor="@color/textPrimary"
-    app:navigationIconTint="@color/textPrimary"
+    app:navigationIconTint="@color/custom_toolbar_icon_tint"
             app:popupTheme="@style/Theme.SpeakKey.PopupOverlay" />
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/activity_prompts.xml
+++ b/app/src/main/res/layout/activity_prompts.xml
@@ -15,9 +15,9 @@
             android:id="@+id/toolbar_prompts"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
-            android:background="?attr/colorPrimary"
+    android:background="@color/custom_toolbar_background"
     app:titleTextColor="@color/textPrimary"
-    app:navigationIconTint="@color/textPrimary"
+    app:navigationIconTint="@color/custom_toolbar_icon_tint"
             app:popupTheme="@style/Theme.SpeakKey.PopupOverlay" />
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -2,4 +2,9 @@
 <resources>
     <!-- Colors specific for dark theme -->
     <color name="edit_text_background">#484848</color> <!-- Dark gray color for text boxes in dark mode -->
+
+    <!-- Custom Toolbar Colors - Dark Theme -->
+    <color name="material_dark_surface">#121212</color>
+    <color name="custom_toolbar_background">@color/material_dark_surface</color>
+    <color name="custom_toolbar_icon_tint">@color/gray</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -14,4 +14,8 @@
     <color name="green">#4CAF50</color>
     
     <color name="edit_text_background">@android:color/white</color> <!-- Default text box background color -->
+
+    <!-- Custom Toolbar Colors - Light Theme -->
+    <color name="custom_toolbar_background">@color/primary</color>
+    <color name="custom_toolbar_icon_tint">@color/textPrimary</color>
 </resources>


### PR DESCRIPTION
This commit updates the Toolbar styling for Prompts, Formatting Tags, and Macros activities to better match the Settings activity, particularly addressing inconsistencies in Dark Mode as per your feedback.

The changes ensure that in Dark Mode, these activities' Toolbars have:
- A background color matching the main screen area (Material dark surface).
- A gray navigation arrow icon.
- White title text.

In Light Mode, they will retain a primary-colored background (black) with white navigation arrow and title text, consistent with how SettingsActivity appears in Light Mode.

Key changes:
- Added new color resources:
    - `custom_toolbar_background`: Resolves to `@color/primary` (black) in light mode and `@color/material_dark_surface` (#121212) in dark mode.
    - `custom_toolbar_icon_tint`: Resolves to `@color/textPrimary` (white) in light mode and `@color/gray` (#757575) in dark mode.
    - `material_dark_surface` (#121212) defined in `values-night/colors.xml`.
- Updated Toolbar definitions in `activity_prompts.xml`, `activity_formatting_tags.xml`, and `activity_macros.xml`:
    - `android:background` set to `@color/custom_toolbar_background`.
    - `app:navigationIconTint` set to `@color/custom_toolbar_icon_tint`.
    - `app:titleTextColor` remains `@color/textPrimary` (white), which contrasts well with both targeted background colors.

You should visually verify these changes in both Light and Dark modes.