### PR TITLE
Fix: Correct Toolbar arrow color and remove divider in Dark Mode

### DIFF
--- a/app/src/main/res/layout/activity_formatting_tags.xml
+++ b/app/src/main/res/layout/activity_formatting_tags.xml
@@ -9,7 +9,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+    android:theme="@style/Theme.SpeakKey.AppBarOverlay"
+    app:elevation="0dp">
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar_formatting_tags"

--- a/app/src/main/res/layout/activity_macros.xml
+++ b/app/src/main/res/layout/activity_macros.xml
@@ -9,7 +9,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:theme="@style/Theme.SpeakKey.AppBarOverlay">
+    android:theme="@style/Theme.SpeakKey.AppBarOverlay"
+    app:elevation="0dp">
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar_macros"

--- a/app/src/main/res/layout/activity_prompts.xml
+++ b/app/src/main/res/layout/activity_prompts.xml
@@ -9,7 +9,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:theme="@style/Theme.SpeakKey.AppBarOverlay">
+    android:theme="@style/Theme.SpeakKey.AppBarOverlay"
+    app:elevation="0dp">
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar_prompts"

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -23,4 +23,8 @@
         <!-- You might also need to set colorPrimary for button backgrounds if they are not appearing correctly -->
         <!-- <item name="colorPrimary">@color/primaryLight</item> -->
     </style>
+
+    <style name="Theme.SpeakKey.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar">
+        <item name="colorControlNormal">@color/gray</item> <!-- Override for dark mode -->
+    </style>
 </resources>


### PR DESCRIPTION
This commit addresses your feedback regarding UI inconsistencies in Dark Mode for the Prompts, Formatting Tags, and Macros activities when compared to the Settings activity.

Specifically:
1.  The navigation back arrow in Prompts and Formatting Tags activities remained white in Dark Mode, instead of the desired gray.
    - This was fixed by defining `Theme.SpeakKey.AppBarOverlay` in `values-night/themes.xml` to override `colorControlNormal` to `@color/gray`.
    - Ensured that the `AppBarLayout` in `activity_prompts.xml`, `activity_formatting_tags.xml`, and `activity_macros.xml` all use this `Theme.SpeakKey.AppBarOverlay`.

2.  A faint divider line (shadow) was visible below the Toolbar in these activities, which was not present in SettingsActivity.
    - This was fixed by setting `app:elevation="0dp"` on the `AppBarLayout` in all three activities' layout files.

These changes should result in the Toolbars for Prompts, Formatting Tags, and Macros activities having a gray back arrow and no sub-toolbar divider line in Dark Mode, aligning them more closely with the Settings activity's appearance. The Toolbar background and title text colors were already correct from previous updates.

You should visually verify these changes in Dark Mode.