### PR TITLE
Fix: Resolve crash in AboutActivity due to ActionBar conflict

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,7 +41,7 @@
             android:name=".ui.AboutActivity"
             android:label="@string/about_activity_title"
             android:parentActivityName=".MainActivity"
-            android:theme="@style/Theme.SpeakKey" />
+            android:theme="@style/Theme.SpeakKey.NoActionBar" />
         <activity
             android:name=".utils.LogActivity"
             android:label="Application Logs"


### PR DESCRIPTION
This commit fixes an IllegalStateException that occurred when launching AboutActivity. The crash was caused by the activity's theme (`Theme.SpeakKey`) providing a default window ActionBar while the activity was also trying to set its own Toolbar (from its layout) as the support action bar.

The fix involves changing the theme for `AboutActivity` in `AndroidManifest.xml` from `@style/Theme.SpeakKey` to `@style/Theme.SpeakKey.NoActionBar`. This removes the default window ActionBar, allowing `AboutActivity` to correctly set up and use its own Toolbar without conflict.