### PR TITLE
Feature: Display active prompts on MainActivity

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -77,6 +77,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     private EditText whisperText, chatGptText;
     private View recordingIndicator;
     private TextView recordingTime;
+    private TextView activePromptsDisplay; // ADD THIS
     private CheckBox chkAutoSendWhisper, chkAutoSendInputStick, chkAutoSendToChatGpt; // Added chkAutoSendToChatGpt
     private CheckBox chk_auto_send_whisper_to_inputstick; // Added
     private EditText currentEditingEditText; // For FullScreenEditTextDialogFragment
@@ -93,6 +94,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     private WhisperApi whisperApi;
     private ChatGptApi chatGptApi;
     private InputStickManager inputStickManager; // Reinstated
+    private PromptManager promptManager; // ADD THIS
     
     // Settings
     private SharedPreferences sharedPreferences;
@@ -137,6 +139,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         // Initialize APIs and MacroRepository
         initializeApis();
         macroRepository = new MacroRepository(getApplicationContext()); // Initialize MacroRepository
+        promptManager = new PromptManager(this); // Initialize PromptManager
         
         // Request permissions
         requestPermissions();
@@ -182,6 +185,12 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         btnSendWhisperToInputStick = findViewById(R.id.btn_send_whisper_to_inputstick);
         chk_auto_send_whisper_to_inputstick = findViewById(R.id.chk_auto_send_whisper_to_inputstick);
         // btnClearAll = findViewById(R.id.btn_clear_all); // Removed
+
+        activePromptsDisplay = findViewById(R.id.active_prompts_display); // ADD THIS
+        activePromptsDisplay.setOnClickListener(v -> { // Optional: make it clickable to go to Prompts screen
+            Intent intent = new Intent(MainActivity.this, com.drgraff.speakkey.data.PromptsActivity.class);
+            startActivity(intent);
+        });
 
         // Set up click listeners
         // setupClickListeners(); // Moved down
@@ -694,6 +703,36 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
         // Refresh active macros
         displayActiveMacros();
+        updateActivePromptsDisplay(); // ADD THIS
+    }
+
+    private void updateActivePromptsDisplay() {
+        if (promptManager == null) { // Should be initialized in onCreate
+            promptManager = new PromptManager(this);
+        }
+        List<Prompt> allPrompts = promptManager.getPrompts();
+        StringBuilder activePromptsText = new StringBuilder();
+        boolean hasActivePrompts = false;
+
+        for (Prompt prompt : allPrompts) {
+            if (prompt.isActive()) {
+                if (hasActivePrompts) {
+                    activePromptsText.append("\n"); // Newline separator
+                }
+                activePromptsText.append(prompt.getName()); // Or prompt.getText() or another relevant field
+                hasActivePrompts = true;
+            }
+        }
+
+        if (activePromptsDisplay != null) { // Check if initialized
+            if (hasActivePrompts) {
+                activePromptsDisplay.setText(activePromptsText.toString());
+                activePromptsDisplay.setVisibility(View.VISIBLE);
+            } else {
+                activePromptsDisplay.setText(""); // Or "No active prompts"
+                activePromptsDisplay.setVisibility(View.GONE);
+            }
+        }
     }
 
     private void displayActiveMacros() {

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -190,7 +190,7 @@
         app:layout_constraintTop_toBottomOf="@id/whisper_text"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/chatgpt_controls"> 
+        app:layout_constraintBottom_toTopOf="@+id/active_prompts_display">
         <!-- The Button @+id/btn_clear_transcription was here. 
              The bottom constraint of whisper_to_inputstick_controls needs to point to chatgpt_controls -->
 
@@ -208,6 +208,25 @@
             android:text="Auto-send"/>
     </LinearLayout>
 
+    <TextView
+        android:id="@+id/active_prompts_display"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:gravity="center_horizontal"
+        android:padding="8dp"
+        android:text="Active Prompts Area"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:textColor="?android:attr/textColorSecondary"
+        android:clickable="true"
+        android:focusable="true"
+        android:background="?attr/selectableItemBackground"
+        app:layout_constraintTop_toBottomOf="@id/whisper_to_inputstick_controls"
+        app:layout_constraintBottom_toTopOf="@id/chatgpt_controls"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <!-- The Button @+id/btn_clear_transcription was here and is now removed. -->
 
     <!-- ChatGPT Controls -->
@@ -218,7 +237,7 @@
         android:orientation="vertical"
         android:gravity="center_horizontal"
         android:layout_marginTop="0dp"
-        app:layout_constraintTop_toBottomOf="@id/whisper_to_inputstick_controls" 
+        app:layout_constraintTop_toBottomOf="@+id/active_prompts_display"
         app:layout_constraintBottom_toTopOf="@id/chatgpt_text">
 
         <LinearLayout


### PR DESCRIPTION
This commit introduces a new section on the main activity screen to display a list of currently active prompts. This provides you with at-a-glance information about which prompts will affect ChatGPT processing. The list of active prompts is also clickable, navigating you directly to the Prompts management screen.

Key changes:
- Added a TextView (ID: `active_prompts_display`) to the `content_main.xml` layout. This TextView is positioned below the "Whisper to InputStick" controls and above the "Send to ChatGPT" controls. It's styled for readability and centered.
- Modified `MainActivity.java`:
    - Initialized the new `active_prompts_display` TextView.
    - Created an `updateActivePromptsDisplay()` method that:
        - Fetches all prompts using `PromptManager`.
        - Filters for active prompts. - Concatenates the names of active prompts (separated by newlines) and displays them in the `active_prompts_display` TextView. - If no prompts are active, the TextView is hidden (set to GONE).
    - Called `updateActivePromptsDisplay()` from `onResume()` to ensure the list is current.
    - Added an `OnClickListener` to the `active_prompts_display` TextView that launches `PromptsActivity`.

This feature enhances your awareness of active prompt configurations and provides a quick navigation path to manage them.