### PR TITLE
fix: Resolve build error due to missing theme attribute

### DIFF
--- a/app/src/main/res/layout/activity_photo_prompts.xml
+++ b/app/src/main/res/layout/activity_photo_prompts.xml
@@ -37,7 +37,7 @@
             android:paddingTop="8dp"
             android:paddingBottom="8dp"
             android:layout_marginBottom="8dp"
-            android:background="?attr/colorSurfaceContainerHighest"
+            android:background="?attr/colorSurface"
             android:elevation="2dp">
 
             <TextView


### PR DESCRIPTION
Changed the background of the model selection layout in `activity_photo_prompts.xml` from the M3 attribute `?attr/colorSurfaceContainerHighest` to the more common Material Components attribute `?attr/colorSurface`.

This resolves a build failure caused by `colorSurfaceContainerHighest` not being found, likely due to your app's theme
(`Theme.MaterialComponents.DayNight.DarkActionBar`) not directly exposing this specific Material 3 attribute with the current Material library version (1.8.0).

Using `?attr/colorSurface` ensures a valid theme attribute is used, allowing the build to pass. The existing elevation on the layout will continue to provide visual separation for the section.