### PR TITLE
fix: Add missing ArrayList import in PhotosActivity

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
@@ -39,8 +39,9 @@ import java.io.ByteArrayOutputStream; // Added
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList; // Added
 import java.util.Date;
-import java.util.List; // Added
+import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.ExecutorService; // Added
 import java.util.concurrent.Executors; // Added


### PR DESCRIPTION
Added the explicit import for `java.util.ArrayList` in `PhotosActivity.java`.

This resolves a 'cannot find symbol: class ArrayList' compilation error that occurred when instantiating `new ArrayList<>()`, even with `java.util.List` already imported. Making the import explicit ensures the compiler can find the class.