### PR TITLE
fix: Declare PhotoPromptsActivity and PhotoPromptEditorActivity in Ma…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -102,6 +102,20 @@
             android:label="Photos"
             android:parentActivityName=".MainActivity"
             android:theme="@style/Theme.SpeakKey.NoActionBar" />
+
+        <activity
+            android:name=".PhotoPromptsActivity"
+            android:exported="false"
+            android:label="@string/photo_prompts_title"
+            android:parentActivityName=".PhotosActivity"
+            android:theme="@style/Theme.SpeakKey.NoActionBar" />
+
+        <activity
+            android:name=".ui.prompts.PhotoPromptEditorActivity"
+            android:exported="false"
+            android:label="@string/photo_prompt_editor_title_add"
+            android:parentActivityName=".PhotoPromptsActivity"
+            android:theme="@style/Theme.SpeakKey.NoActionBar" />
     </application>
 
     <queries>


### PR DESCRIPTION
…nifest

I added <activity> declarations for `PhotoPromptsActivity` and `PhotoPromptEditorActivity` to `app/src/main/AndroidManifest.xml`.

This resolves an `ActivityNotFoundException` that occurred at runtime when attempting to navigate to `PhotoPromptsActivity` because it was not declared in the manifest. I also added the declaration for `PhotoPromptEditorActivity` proactively to prevent a similar crash when it would be launched.