### PR TITLE
refactor: Apply UI refinements to PhotosActivity

### DIFF
--- a/app/src/main/res/layout/activity_photos.xml
+++ b/app/src/main/res/layout/activity_photos.xml
@@ -71,21 +71,29 @@
                 android:text="@string/photos_active_prompts_default_text"
                 android:layout_marginBottom="8dp"
                 android:padding="8dp"
-                android:background="#f0f0f0"/>
+                android:background="?attr/colorSurfaceVariant"/>
 
-            <CheckBox
-                android:id="@+id/chk_auto_send_chatgpt_photo"
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/photos_chk_auto_send_chatgpt_text"
-                android:layout_marginBottom="4dp"/>
+                android:orientation="horizontal"
+                android:layout_gravity="center_horizontal"
+                android:gravity="center_vertical"
+                android:layout_marginBottom="8dp">
 
-            <Button
-                android:id="@+id/btn_send_to_chatgpt_photo"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/photos_btn_send_chatgpt_text"
-                android:layout_marginBottom="8dp"/>
+                <Button
+                    android:id="@+id/btn_send_to_chatgpt_photo"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/photos_btn_send_chatgpt_text"
+                    android:layout_marginEnd="8dp"/>
+
+                <CheckBox
+                    android:id="@+id/chk_auto_send_chatgpt_photo"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/photos_chk_auto_send_chatgpt_text"/>
+            </LinearLayout>
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -114,18 +122,28 @@
                     android:padding="8dp"/>
             </LinearLayout>
 
-            <CheckBox
-                android:id="@+id/chk_auto_send_inputstick_photo"
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/photos_chk_auto_send_inputstick_text"
-                android:layout_marginBottom="4dp"/>
+                android:orientation="horizontal"
+                android:layout_gravity="center_horizontal"
+                android:gravity="center_vertical"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="8dp">
 
-            <Button
-                android:id="@+id/btn_send_to_inputstick_photo"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/photos_btn_send_inputstick_text"/>
+                <Button
+                    android:id="@+id/btn_send_to_inputstick_photo"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/photos_btn_send_inputstick_text"
+                    android:layout_marginEnd="8dp"/>
+
+                <CheckBox
+                    android:id="@+id/chk_auto_send_inputstick_photo"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/photos_chk_auto_send_inputstick_text"/>
+            </LinearLayout>
 
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
This commit addresses your feedback regarding UI elements in PhotosActivity:

1.  **Fix Dark Mode Text Visibility:** Changed the `android:background` of the `text_active_photo_prompts_display` TextView from a hardcoded light color to `?attr/colorSurfaceVariant`. This ensures the background is theme-aware and provides proper contrast for the text in both light and dark modes, resolving an issue where light text was displayed on a light background in dark mode.

2.  **Adjust Button/Checkbox Layouts:**
    - Modified the layout for the "Send to ChatGPT" button and its "Auto-send" checkbox to be on a single horizontal line, centered, with the button width set to `wrap_content`.
    - Applied the same layout adjustments to the "Send to InputStick" button and its "Auto-send" checkbox. This makes the layout of these controls consistent with similar patterns in MainActivity and improves visual organization.