### PR TITLE
fix: Resolve InflateException in PhotosActivity for TextView background

### DIFF
--- a/app/src/main/res/layout/activity_photos.xml
+++ b/app/src/main/res/layout/activity_photos.xml
@@ -70,8 +70,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/photos_active_prompts_default_text"
                 android:layout_marginBottom="8dp"
-                android:padding="8dp"
-                android:background="?attr/colorSurfaceVariant"/>
+                android:padding="8dp" />
 
             <LinearLayout
                 android:layout_width="wrap_content"


### PR DESCRIPTION
Removed the `android:background` attribute from the TextView (ID `text_active_photo_prompts_display`) in `activity_photos.xml`.

This TextView was previously using `?attr/colorSurfaceVariant` for its background, which caused an `InflateException` at runtime due to the attribute not being resolved in the `PhotosActivity`'s theme context.

By removing the explicit background, the TextView will now have a transparent background, inheriting from its parent. This resolves the crash and also ensures that the theme-aware text color has proper contrast against the activity's themed background in both light and dark modes.