### PR TITLE
refactor: Apply UI styling refinements to PhotosActivity

### DIFF
--- a/app/src/main/res/layout/activity_photos.xml
+++ b/app/src/main/res/layout/activity_photos.xml
@@ -104,12 +104,20 @@
                 <EditText
                     android:id="@+id/edittext_chatgpt_response_photo"
                     android:layout_width="0dp"
-                    android:layout_height="wrap_content"
+                    android:layout_height="180dp"
                     android:layout_weight="1"
                     android:hint="@string/photos_edittext_chatgpt_response_hint_text"
                     android:inputType="textMultiLine"
                     android:minLines="3"
-                    android:background="@android:drawable/edit_text"/>
+                    android:maxLines="100"
+                    android:background="@color/edit_text_background"
+                    android:padding="8dp"
+                    android:gravity="top|start"
+                    android:scrollbars="vertical"
+                    android:fadeScrollbars="false"
+                    android:nestedScrollingEnabled="true"
+                    android:focusable="true"
+                    android:focusableInTouchMode="true" />
 
                 <ImageButton
                     android:id="@+id/btn_clear_chatgpt_response_photo"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,11 +132,11 @@ SpeakKey streamlines data entry, coding, writing, and any task involving text in
     <string name="photos_btn_prompts_text">Photo Prompts</string>
     <string name="photos_active_prompts_default_text">Active Photo Prompts Display</string>
     <string name="photos_text_no_active_prompts">No active photo prompts. Click to configure.</string>
-    <string name="photos_chk_auto_send_chatgpt_text">Auto-send to ChatGPT</string>
+    <string name="photos_chk_auto_send_chatgpt_text">Auto-send</string>
     <string name="photos_btn_send_chatgpt_text">Send to ChatGPT</string>
     <string name="photos_edittext_chatgpt_response_hint_text">ChatGPT Response</string>
     <string name="photos_btn_clear_chatgpt_response_desc_text">Clear ChatGPT Response</string>
-    <string name="photos_chk_auto_send_inputstick_text">Auto-send to InputStick</string>
+    <string name="photos_chk_auto_send_inputstick_text">Auto-send</string>
     <string name="photos_btn_send_inputstick_text">Send to InputStick</string>
     <string name="photos_toast_api_key_not_set_chatgpt">OpenAI API Key is not set. Cannot send to ChatGPT.</string>
     <string name="photos_progress_sending_to_chatgpt_message">Sending to ChatGPT...</string>


### PR DESCRIPTION
This commit addresses your feedback for UI consistency in PhotosActivity:

1.  **Standardize "Auto-send" CheckBox Text:** Modified the string resources `photos_chk_auto_send_chatgpt_text` and `photos_chk_auto_send_inputstick_text` in `strings.xml` to have the value "Auto-send". This makes the labels for these CheckBoxes consistent with similar controls in MainActivity.

2.  **Match EditText Style for "ChatGPT Response":** Updated the styling of the `edittext_chatgpt_response_photo` EditText in `activity_photos.xml` to align with the appearance and behavior of EditTexts in MainActivity. Changes include:
    - Setting a fixed height (`180dp`).
    - Applying the custom `@color/edit_text_background`.
    - Adding standard padding, top-start gravity, and vertical scrollbars.
    - Ensuring it's directly focusable and editable.