### PR TITLE
refactor: Redesign 'Take Photo' button in PhotosActivity as large icon

### DIFF
--- a/app/src/main/res/layout/activity_photos.xml
+++ b/app/src/main/res/layout/activity_photos.xml
@@ -32,20 +32,24 @@
             android:orientation="vertical"
             android:padding="16dp">
 
-            <Button
+            <ImageButton
                 android:id="@+id/btn_take_photo_area"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/photos_btn_take_photo_text"
+                android:layout_height="180dp"
+                android:src="@android:drawable/ic_menu_camera"
+                android:scaleType="fitCenter"
+                android:padding="24dp"
+                android:background="?attr/selectableItemBackground"
+                android:contentDescription="@string/photos_btn_take_photo_text"
                 android:layout_marginBottom="8dp"/>
 
             <ImageView
                 android:id="@+id/image_view_photo"
                 android:layout_width="match_parent"
-                android:layout_height="200dp"
+                android:layout_height="180dp"
                 android:visibility="gone"
                 android:layout_marginBottom="8dp"
-                android:background="#e0e0e0"
+                android:background="?attr/colorSurface"
                 android:scaleType="centerInside"
                 android:contentDescription="@string/photos_image_captured_desc"/>
 


### PR DESCRIPTION
Replaced the standard "Take Photo" Button in PhotosActivity with an ImageButton that displays a large camera icon (`@android:drawable/ic_menu_camera`). The ImageButton (ID `btn_take_photo_area`) is set to `match_parent` width and a height of `180dp`, with appropriate scaling and padding for the icon.

The ImageView (ID `image_view_photo`) that displays the captured photo has also been adjusted to a height of `180dp` to match the ImageButton it replaces. Its background has been changed from a hardcoded color to `?attr/colorSurface` for better theme consistency.

This addresses your feedback to make the photo-taking trigger a large, icon-based button and ensures the subsequent photo display area has consistent dimensions.