### PR TITLE
refactor: Add warning log when no camera app is found

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
@@ -337,6 +337,7 @@ public class PhotosActivity extends AppCompatActivity {
                 startActivityForResult(takePictureIntent, REQUEST_IMAGE_CAPTURE);
             }
         } else {
+            Log.w(TAG, "No activity found to handle ACTION_IMAGE_CAPTURE intent. Ensure a camera app is installed and enabled in the emulator/device.");
             Toast.makeText(this, getString(R.string.photos_toast_no_camera_app_found), Toast.LENGTH_SHORT).show();
         }
     }


### PR DESCRIPTION
Added a `Log.w` statement in `PhotosActivity.dispatchTakePictureIntent()` for the case where `resolveActivity()` returns null. This provides clearer debugging information in Logcat when the system cannot find an activity to handle the `ACTION_IMAGE_CAPTURE` intent.

The primary cause of the "No camera app found" toast is likely an emulator/device environment issue where no camera app is installed or enabled, as the intent dispatch code is standard.