### PR TITLE
fix: Add camera intent query to Manifest for package visibility

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -120,6 +120,9 @@
 
     <queries>
         <package android:name="com.inputstick.apps.inputstickutility" />
+        <intent>
+            <action android:name="android.media.action.IMAGE_CAPTURE" />
+        </intent>
     </queries>
 
 </manifest>


### PR DESCRIPTION
Added an <intent> query for `android.media.action.IMAGE_CAPTURE` to the `<queries>` section in `AndroidManifest.xml`.

This addresses an issue where `resolveActivity()` might not find an installed camera app on devices running Android 11 (API 30) or higher due to package visibility restrictions. Explicitly declaring this intent query allows the PackageManager to correctly identify and resolve activities capable of handling image capture.

This should fix the "No camera app found" error you reported on a physical Pixel device.