### PR TITLE
feat: Implement full-screen dialog editing for Photos response EditText

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
@@ -52,10 +52,11 @@ import com.drgraff.speakkey.api.ChatGptRequest;
 import com.drgraff.speakkey.data.PhotoPrompt;
 import com.drgraff.speakkey.data.PhotoPromptManager;
 import com.drgraff.speakkey.inputstick.InputStickBroadcast; // Added
-import com.drgraff.speakkey.inputstick.InputStickManager; // Added
-import com.drgraff.speakkey.utils.AppLogManager; // Added
+import com.drgraff.speakkey.inputstick.InputStickManager;
+import com.drgraff.speakkey.utils.AppLogManager;
+import com.drgraff.speakkey.FullScreenEditTextDialogFragment; // Added
 
-public class PhotosActivity extends AppCompatActivity {
+public class PhotosActivity extends AppCompatActivity implements FullScreenEditTextDialogFragment.OnSaveListener { // Added interface
 
     private static final String TAG = "PhotosActivity";
     private static final int REQUEST_CAMERA_PERMISSION = 101;
@@ -176,7 +177,12 @@ public class PhotosActivity extends AppCompatActivity {
             startActivity(intent);
         });
 
-        btnSendToChatGptPhoto.setOnClickListener(v -> sendPhotoAndPromptsToChatGpt()); // Added
+        btnSendToChatGptPhoto.setOnClickListener(v -> sendPhotoAndPromptsToChatGpt());
+
+        editTextChatGptResponsePhoto.setOnClickListener(v -> { // Added listener
+            FullScreenEditTextDialogFragment dialogFragment = FullScreenEditTextDialogFragment.newInstance(editTextChatGptResponsePhoto.getText().toString());
+            dialogFragment.show(getSupportFragmentManager(), "edit_chatgpt_response_photo_dialog");
+        });
 
         if (savedInstanceState != null) {
             currentPhotoPath = savedInstanceState.getString(KEY_PHOTO_PATH);
@@ -474,6 +480,13 @@ public class PhotosActivity extends AppCompatActivity {
         } else {
             AppLogManager.getInstance().addEntry("WARN", "PhotosActivity: InputStick Utility not supported or user cancelled download.", null);
             // isSupported() already shows a dialog if not installed/updated.
+        }
+    }
+
+    @Override // Added method
+    public void onSave(String editedText) {
+        if (editTextChatGptResponsePhoto != null) {
+            editTextChatGptResponsePhoto.setText(editedText);
         }
     }
 }

--- a/app/src/main/res/layout/activity_photos.xml
+++ b/app/src/main/res/layout/activity_photos.xml
@@ -120,8 +120,9 @@
                     android:scrollbars="vertical"
                     android:fadeScrollbars="false"
                     android:nestedScrollingEnabled="true"
-                    android:focusable="true"
-                    android:focusableInTouchMode="true" />
+                    android:focusable="false"
+                    android:clickable="true"
+                    android:drawableEnd="?android:attr/actionModeWebSearchDrawable" />
 
                 <ImageButton
                     android:id="@+id/btn_clear_chatgpt_response_photo"


### PR DESCRIPTION
I modified the `edittext_chatgpt_response_photo` EditText in `PhotosActivity` to launch a `FullScreenEditTextDialogFragment` when clicked, similar to the EditTexts in `MainActivity`.

Changes include:
- Updated XML attributes for `edittext_chatgpt_response_photo` to be `focusable="false"` and `clickable="true"`, and added a `drawableEnd` visual cue.
- `PhotosActivity` now implements `FullScreenEditTextDialogFragment.OnSaveListener`.
- An `OnClickListener` on the EditText launches the dialog.
- The `onSave` callback in `PhotosActivity` updates the EditText with the text from the dialog.

This aligns the editing behavior of the ChatGPT response field in PhotosActivity with your expectation based on MainActivity.