### PR TITLE
refactor: Adjust styling for active photo prompts display

### DIFF
--- a/app/src/main/res/layout/activity_photos.xml
+++ b/app/src/main/res/layout/activity_photos.xml
@@ -82,7 +82,9 @@
                 android:layout_height="wrap_content"
                 android:text="@string/photos_active_prompts_default_text"
                 android:layout_marginBottom="8dp"
-                android:padding="8dp" />
+                android:padding="8dp"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:gravity="center_horizontal" />
 
             <LinearLayout
                 android:layout_width="wrap_content"


### PR DESCRIPTION
Updated the TextView (ID `text_active_photo_prompts_display`) in `activity_photos.xml` to make the text larger and centered, as per your feedback.

Changes include:
- Set `android:textAppearance="?android:attr/textAppearanceMedium"` for a larger, theme-consistent text size.
- Set `android:gravity="center_horizontal"` to center the text content within the TextView.