### PR TITLE
fix: Correct unclosed LinearLayout in activity_photos.xml

### DIFF
--- a/app/src/main/res/layout/activity_photos.xml
+++ b/app/src/main/res/layout/activity_photos.xml
@@ -166,8 +166,8 @@
                     android:layout_height="wrap_content"
                     android:text="@string/photos_chk_auto_send_inputstick_text"/>
             </LinearLayout>
-
-        </LinearLayout>
+        </LinearLayout> <!-- This closes the inner LinearLayout with paddingStart/End -->
+    </LinearLayout> <!-- This closes the main LinearLayout child of NestedScrollView -->
     </androidx.core.widget.NestedScrollView>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Added a missing closing </LinearLayout> tag in
`app/src/main/res/layout/activity_photos.xml`.

This tag was for the main LinearLayout container within the NestedScrollView, which was inadvertently left unclosed during previous layout restructuring.

This resolves an XML parsing error that caused the build to fail during resource processing.