### PR TITLE
feat: Set default photo model and add instructional text in PhotoPrompts

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/PhotoPromptsActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/PhotoPromptsActivity.java
@@ -225,8 +225,8 @@ public class PhotoPromptsActivity extends AppCompatActivity implements PhotoProm
         }
         modelAdapter.notifyDataSetChanged();
 
-        String selectedModelId = sharedPreferences.getString(PREF_KEY_SELECTED_PHOTO_MODEL, null);
-        if (selectedModelId != null && !modelList.isEmpty()) {
+        String selectedModelId = sharedPreferences.getString(PREF_KEY_SELECTED_PHOTO_MODEL, "gpt-4-vision-preview");
+        if (selectedModelId != null && !modelList.isEmpty()) { // selectedModelId will not be null due to default
             int spinnerPosition = modelAdapter.getPosition(selectedModelId);
             if (spinnerPosition >= 0) {
                 spinnerPhotoModels.setSelection(spinnerPosition);

--- a/app/src/main/res/layout/activity_photo_prompts.xml
+++ b/app/src/main/res/layout/activity_photo_prompts.xml
@@ -41,6 +41,14 @@
             android:elevation="2dp">
 
             <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/photo_prompts_model_selection_instruction"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:layout_marginBottom="8dp"/>
+                <!-- The model_selection_layout already has paddingTop/Bottom and its children have start/end margins -->
+
+            <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/photo_prompts_label_model_selection"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,6 +158,7 @@ SpeakKey streamlines data entry, coding, writing, and any task involving text in
 
     <!-- Photo Prompts Feature -->
     <string name="photo_prompts_title">Photo Prompts</string>
+    <string name="photo_prompts_model_selection_instruction">Choose a model for photo processing:</string>
     <string name="photo_prompts_label_model_selection">Photo Model:</string>
     <string name="photo_prompts_btn_check_models">Check ChatGPT Photo Models</string>
     <string name="photo_prompts_empty_text">No photo prompts created yet. Click the \'+\' button to add one.</string>


### PR DESCRIPTION
Changes in PhotoPromptsActivity and its layout:
1.  Added an instructional TextView ("Choose a model for photo processing:") above the model selection spinner to guide you.
2.  Set the default photo processing model to "gpt-4-vision-preview" in `PhotoPromptsActivity.java`. This model will be selected by default if no preference is already saved and if the model is available in the loaded list.

These changes improve your experience by providing better guidance and a sensible default for photo model selection.