### PR TITLE
refactor: Remove debug toast from InputStickManager.typeText()

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/inputstick/InputStickManager.java
+++ b/app/src/main/java/com/drgraff/speakkey/inputstick/InputStickManager.java
@@ -51,7 +51,7 @@ public class InputStickManager {
     public void typeText(String text) {
         // Initial checks and logging on the calling thread
         AppLogManager.getInstance().addEntry("INFO", TAG, "typeText() entered. Text snippet: " + (text != null && text.length() > 20 ? text.substring(0, 20) : text));
-        Toast.makeText(context, "IM.typeText() called", Toast.LENGTH_SHORT).show(); // This Toast remains on UI thread
+        // Toast.makeText(context, "IM.typeText() called", Toast.LENGTH_SHORT).show(); // This Toast remains on UI thread
 
         if (text == null || text.isEmpty()) {
             Log.e(TAG, "Text is null or empty");


### PR DESCRIPTION
I commented out the Toast message "IM.typeText() called" in the `typeText()` method of `InputStickManager.java`.

This toast was identified as not useful to you. The subsequent toast "Text sent to InputStick" (from PhotosActivity) provides appropriate user feedback. An existing AppLogManager entry already logs the call to `typeText()` for debugging purposes.