### PR TITLE
Here's the rewritten message, Jules:

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -83,6 +83,8 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     private ImageButton btnClearChatGptIcon; // Added
     private Button btnSendInputStick;
     private Button btnSendWhisperToInputStick; // Added
+    private ImageButton btnShareWhisperText; // Added
+    private ImageButton btnShareChatGptText; // Added
     private EditText whisperText, chatGptText;
     private View recordingIndicator;
     private TextView recordingTime;
@@ -208,12 +210,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         // btnClearRecording = findViewById(R.id.btn_clear_recording); // Removed
         btnClearAllWhisperIcon = findViewById(R.id.btn_clear_all_whisper_icon); // Added
         btnClearTranscriptionIcon = findViewById(R.id.btn_clear_transcription_icon); // Initialize new ImageButton
+        btnShareWhisperText = findViewById(R.id.btn_share_whisper_text); // Initialize Share Whisper Button
         chkAutoSendWhisper = findViewById(R.id.chk_auto_send_whisper);
         
         // ChatGPT section
         chatGptText = findViewById(R.id.chatgpt_text);
         btnSendChatGpt = findViewById(R.id.btn_send_chatgpt);
         btnClearChatGptIcon = findViewById(R.id.btn_clear_chatgpt_icon); // Initialize new ImageButton
+        btnShareChatGptText = findViewById(R.id.btn_share_chatgpt_text); // Initialize Share ChatGPT Button
         chkAutoSendToChatGpt = findViewById(R.id.chk_auto_send_to_chatgpt);
         
         // InputStick section
@@ -362,6 +366,53 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             });
         }
         // The old btnClearAll listener is removed by not including it here.
+
+        if (btnShareWhisperText != null) {
+            btnShareWhisperText.setOnClickListener(v -> {
+                String textToShare = whisperText.getText().toString();
+                if (!textToShare.isEmpty() && !isPlaceholderOrError(textToShare)) {
+                    Intent shareIntent = new Intent(Intent.ACTION_SEND);
+                    shareIntent.setType("text/plain");
+                    shareIntent.putExtra(Intent.EXTRA_TEXT, textToShare);
+                    startActivity(Intent.createChooser(shareIntent, getString(R.string.main_share_chooser_title_text)));
+                } else {
+                    Toast.makeText(MainActivity.this, "No valid content to share", Toast.LENGTH_SHORT).show();
+                }
+            });
+        }
+
+        if (btnShareChatGptText != null) {
+            btnShareChatGptText.setOnClickListener(v -> {
+                String textToShare = chatGptText.getText().toString();
+                if (!textToShare.isEmpty()) { // ChatGPT text is less likely to be a placeholder from the app
+                    Intent shareIntent = new Intent(Intent.ACTION_SEND);
+                    shareIntent.setType("text/plain");
+                    shareIntent.putExtra(Intent.EXTRA_TEXT, textToShare);
+                    startActivity(Intent.createChooser(shareIntent, getString(R.string.main_share_chooser_title_text)));
+                } else {
+                    Toast.makeText(MainActivity.this, "No content to share", Toast.LENGTH_SHORT).show();
+                }
+            });
+        }
+    }
+
+    private boolean isPlaceholderOrError(String text) {
+        if (text == null || text.isEmpty()) {
+            return true;
+        }
+        // Check against the specific placeholder string
+        if (TRANSCRIPTION_QUEUED_PLACEHOLDER.equals(text)) {
+            return true;
+        }
+        // Check for bracketed status messages like "[UPLOADING... Tap to refresh]"
+        if (text.startsWith("[") && text.endsWith("... Tap to refresh]")) {
+            return true;
+        }
+        // Check for common failure keywords
+        if (text.toLowerCase().contains("failed") || text.toLowerCase().contains("error")) {
+            return true;
+        }
+        return false;
     }
     
     private void requestPermissions() {

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -143,41 +143,62 @@
         app:layout_constraintTop_toBottomOf="@id/whisper_controls"
         app:layout_constraintStart_toStartOf="parent" />
 
-    <ImageButton
-        android:id="@+id/btn_clear_transcription_icon"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@android:drawable/ic_menu_delete"
-        android:contentDescription="@string/clear_transcription"
-        android:background="?attr/selectableItemBackgroundBorderless"
-        android:padding="4dp"
-        android:layout_marginStart="8dp"
-        app:layout_constraintStart_toEndOf="@id/whisper_label"
-        app:layout_constraintTop_toTopOf="@id/whisper_label"
-        app:layout_constraintBottom_toBottomOf="@id/whisper_label"/>
-
-    <EditText
-        android:id="@+id/whisper_text"
+    <LinearLayout
+        android:id="@+id/whisper_text_container"
         android:layout_width="match_parent"
-        android:layout_height="180dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
         android:layout_marginTop="0dp"
         android:layout_marginBottom="2dp"
-        android:background="@color/edit_text_background"
-        android:hint="Transcribed text will appear here"
-        android:padding="8dp"
-        android:paddingEnd="12dp"
-        android:gravity="top|start"
-        android:inputType="textMultiLine"
-        android:drawableEnd="?android:attr/actionModeWebSearchDrawable"
-        android:focusable="false"
-        android:clickable="true"
-        android:scrollbars="vertical"
-        android:fadeScrollbars="false"
-        android:nestedScrollingEnabled="true"
-        android:minLines="3"
-        android:maxLines="100"
         app:layout_constraintTop_toBottomOf="@id/whisper_label"
-        app:layout_constraintBottom_toTopOf="@+id/whisper_to_inputstick_controls" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/whisper_to_inputstick_controls">
+
+        <EditText
+            android:id="@+id/whisper_text"
+            android:layout_width="0dp"
+            android:layout_height="180dp"
+            android:layout_weight="1"
+            android:background="@color/edit_text_background"
+            android:hint="Transcribed text will appear here"
+            android:padding="8dp"
+            android:gravity="top|start"
+            android:inputType="textMultiLine"
+            android:drawableEnd="?android:attr/actionModeWebSearchDrawable"
+            android:focusable="false"
+            android:clickable="true"
+            android:scrollbars="vertical"
+            android:fadeScrollbars="false"
+            android:nestedScrollingEnabled="true"
+            android:minLines="3"
+            android:maxLines="100"/>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_marginStart="4dp">
+
+            <ImageButton
+                android:id="@+id/btn_clear_transcription_icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@android:drawable/ic_menu_delete"
+                android:contentDescription="@string/clear_transcription"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:padding="8dp"/>
+
+            <ImageButton
+                android:id="@+id/btn_share_whisper_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@android:drawable/ic_menu_share"
+                android:contentDescription="@string/main_btn_share_whisper_desc"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:padding="8dp"/>
+        </LinearLayout>
+    </LinearLayout>
 
     <LinearLayout
         android:id="@+id/whisper_to_inputstick_controls"
@@ -238,7 +259,7 @@
         android:gravity="center_horizontal"
         android:layout_marginTop="0dp"
         app:layout_constraintTop_toBottomOf="@+id/active_prompts_display"
-        app:layout_constraintBottom_toTopOf="@id/chatgpt_text">
+        app:layout_constraintBottom_toTopOf="@id/chatgpt_text_container">
 
         <LinearLayout
             android:layout_width="wrap_content"
@@ -274,41 +295,62 @@
         app:layout_constraintTop_toBottomOf="@id/chatgpt_controls"
         app:layout_constraintStart_toStartOf="parent" />
 
-    <ImageButton
-        android:id="@+id/btn_clear_chatgpt_icon"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@android:drawable/ic_menu_delete"
-        android:contentDescription="@string/clear_chatgpt_response"
-        android:background="?attr/selectableItemBackgroundBorderless"
-        android:padding="4dp"
-        android:layout_marginStart="8dp"
-        app:layout_constraintStart_toEndOf="@id/chatgpt_label"
-        app:layout_constraintTop_toTopOf="@id/chatgpt_label"
-        app:layout_constraintBottom_toBottomOf="@id/chatgpt_label"/>
-
-    <EditText
-        android:id="@+id/chatgpt_text"
+    <LinearLayout
+        android:id="@+id/chatgpt_text_container"
         android:layout_width="match_parent"
-        android:layout_height="180dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
         android:layout_marginTop="8dp"
         android:layout_marginBottom="2dp"
-        android:background="@color/edit_text_background"
-        android:hint="ChatGPT response will appear here"
-        android:padding="8dp"
-        android:paddingEnd="12dp"
-        android:gravity="top|start"
-        android:inputType="textMultiLine"
-        android:drawableEnd="?android:attr/actionModeWebSearchDrawable"
-        android:focusable="false"
-        android:clickable="true"
-        android:scrollbars="vertical"
-        android:fadeScrollbars="false"
-        android:nestedScrollingEnabled="true"
-        android:minLines="3"
-        android:maxLines="100"
         app:layout_constraintTop_toBottomOf="@id/chatgpt_label"
-        app:layout_constraintBottom_toTopOf="@id/inputstick_controls" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/inputstick_controls">
+
+        <EditText
+            android:id="@+id/chatgpt_text"
+            android:layout_width="0dp"
+            android:layout_height="180dp"
+            android:layout_weight="1"
+            android:background="@color/edit_text_background"
+            android:hint="ChatGPT response will appear here"
+            android:padding="8dp"
+            android:gravity="top|start"
+            android:inputType="textMultiLine"
+            android:drawableEnd="?android:attr/actionModeWebSearchDrawable"
+            android:focusable="false"
+            android:clickable="true"
+            android:scrollbars="vertical"
+            android:fadeScrollbars="false"
+            android:nestedScrollingEnabled="true"
+            android:minLines="3"
+            android:maxLines="100"/>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_marginStart="4dp">
+
+            <ImageButton
+                android:id="@+id/btn_clear_chatgpt_icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@android:drawable/ic_menu_delete"
+                android:contentDescription="@string/clear_chatgpt_response"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:padding="8dp"/>
+
+            <ImageButton
+                android:id="@+id/btn_share_chatgpt_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@android:drawable/ic_menu_share"
+                android:contentDescription="@string/main_btn_share_chatgpt_desc"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:padding="8dp"/>
+        </LinearLayout>
+    </LinearLayout>
 
     <!-- InputStick Section -->
     <LinearLayout
@@ -319,7 +361,7 @@
         android:gravity="center"
         android:layout_marginTop="4dp"
         android:layout_marginBottom="2dp"
-        app:layout_constraintTop_toBottomOf="@id/chatgpt_text"
+        app:layout_constraintTop_toBottomOf="@id/chatgpt_text_container"
         app:layout_constraintBottom_toBottomOf="parent">
 
         <Button

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -189,4 +189,9 @@ SpeakKey streamlines data entry, coding, writing, and any task involving text in
     <string name="photos_btn_share_chatgpt_response_desc_text">Share response</string>
     <string name="photos_share_chooser_title_text">Share via</string>
 
+    <!-- MainActivity Share Buttons -->
+    <string name="main_btn_share_whisper_desc">Share Whisper text</string>
+    <string name="main_btn_share_chatgpt_desc">Share ChatGPT text</string>
+    <string name="main_share_chooser_title_text">Share content via</string>
+
 </resources>


### PR DESCRIPTION
feat: Add share buttons to MainActivity text areas

This commit introduces share buttons in MainActivity for both the Whisper transcription and ChatGPT response text areas, mirroring the functionality recently added to PhotosActivity.

Key changes:
- Updated `content_main.xml` (included in `activity_main.xml`):
    - For the Whisper text area: - Added a new ImageButton (`btn_share_whisper_text`) with a standard share icon. - Positioned it below the clear button, in a vertical LinearLayout to the right of `whisperText`.
    - For the ChatGPT text area:
        - Added a new ImageButton (`btn_share_chatgpt_text`) with a standard share icon.
        - Positioned it below the clear button, in a vertical LinearLayout to the right of `chatGptText`.
- Added new string resources in `strings.xml` for:
    - Content descriptions for the new share buttons (`main_btn_share_whisper_desc`, `main_btn_share_chatgpt_desc`).
    - The title of the share chooser dialog (`main_share_chooser_title_text`).
- Modified `MainActivity.java`:
    - Initialized the new ImageButtons.
    - Implemented OnClickListeners for both share buttons.
    - Share logic retrieves text from the respective EditText and uses an ACTION_SEND Intent.
    - Added checks to prevent sharing of empty, placeholder, or error messages from `whisperText`, showing a Toast instead.
    - Added an empty check for `chatGptText` before sharing.

I've also prepared a way for you to manually verify this functionality.