### PR TITLE
feat: Implement selectable transcription mode and update PromptsActiv…

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/data/PromptsActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/data/PromptsActivity.java
@@ -7,6 +7,16 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 // Removed Button, EditText, Toast (Toast might be re-added if needed for other purposes)
+import android.app.ProgressDialog;
+import android.content.SharedPreferences;
+import android.os.Handler;
+import android.os.Looper;
+import android.preference.PreferenceManager;
+import android.util.Log;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.Spinner;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -17,11 +27,19 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.drgraff.speakkey.R;
+import com.drgraff.speakkey.api.ChatGptApi;
+import com.drgraff.speakkey.api.OpenAIModelData;
 import com.drgraff.speakkey.ui.prompts.PromptEditorActivity; // Correct path for PromptEditorActivity
 import com.google.android.material.floatingactionbutton.FloatingActionButton; // Added for FAB
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 public class PromptsActivity extends AppCompatActivity { // Removed PromptsAdapter.OnPromptInteractionListener
 
@@ -31,6 +49,22 @@ public class PromptsActivity extends AppCompatActivity { // Removed PromptsAdapt
     // Removed promptList as adapter will hold its own list
     private TextView emptyPromptsTextView; // Added for empty state
     private FloatingActionButton fabAddPrompt; // Added for FAB
+
+    private Button btnCheckChatGptModels; // For prompts
+    private Spinner spinnerChatGptModels; // For prompts
+
+    private ChatGptApi chatGptApi;
+    private SharedPreferences sharedPreferences;
+    private ProgressDialog progressDialog;
+    private final ExecutorService executorService = Executors.newSingleThreadExecutor(); // Or re-use if one exists
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private List<String> modelListPrompts = new ArrayList<>();
+    private ArrayAdapter<String> modelAdapterPrompts;
+
+    // Define new preference keys for this activity's model selection
+    public static final String PREF_KEY_SELECTED_CHATGPT_MODEL_PROMPTS = "selected_chatgpt_model_prompts";
+    public static final String PREF_KEY_FETCHED_CHATGPT_MODEL_IDS_PROMPTS = "fetched_chatgpt_model_ids_prompts";
+
 
     // Removed promptInputText, addPromptButton, currentEditingPrompt
 
@@ -50,11 +84,53 @@ public class PromptsActivity extends AppCompatActivity { // Removed PromptsAdapt
             actionBar.setTitle(R.string.prompts_activity_title);
         }
 
+        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+        String apiKey = sharedPreferences.getString("openai_api_key", "");
+        String openAiModel = sharedPreferences.getString(PREF_KEY_SELECTED_CHATGPT_MODEL_PROMPTS, "gpt-3.5-turbo"); // Default model
+        chatGptApi = new ChatGptApi(apiKey, openAiModel);
+
+
         promptManager = new PromptManager(this);
 
         promptsRecyclerView = findViewById(R.id.prompts_recycler_view);
         emptyPromptsTextView = findViewById(R.id.empty_prompts_text_view); // Initialize empty view
         fabAddPrompt = findViewById(R.id.fab_add_prompt); // Initialize FAB
+
+        btnCheckChatGptModels = findViewById(R.id.btn_check_chatgpt_models_prompts);
+        spinnerChatGptModels = findViewById(R.id.spinner_chatgpt_models_prompts);
+
+        modelAdapterPrompts = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, modelListPrompts);
+        modelAdapterPrompts.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        spinnerChatGptModels.setAdapter(modelAdapterPrompts);
+
+        if (apiKey.isEmpty()) {
+            btnCheckChatGptModels.setEnabled(false);
+            btnCheckChatGptModels.setText(R.string.api_key_not_set_short); // Assuming you have this string
+        } else {
+            btnCheckChatGptModels.setEnabled(true);
+            btnCheckChatGptModels.setText("Check Models"); // Or from strings.xml
+        }
+
+        btnCheckChatGptModels.setOnClickListener(v -> fetchChatGptModelsAndUpdateSpinner());
+
+        spinnerChatGptModels.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                String selectedModel = (String) parent.getItemAtPosition(position);
+                sharedPreferences.edit().putString(PREF_KEY_SELECTED_CHATGPT_MODEL_PROMPTS, selectedModel).apply();
+                // Update chatGptApi if model changes, or ensure it's read fresh when used
+                if (chatGptApi != null) {
+                    chatGptApi.setModel(selectedModel);
+                }
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+            }
+        });
+
+        loadAndPopulateChatGptModelsSpinner();
+
 
         promptsRecyclerView.setLayoutManager(new LinearLayoutManager(this));
         // PromptsAdapter constructor was changed to PromptsAdapter(Context context, List<Prompt> prompts, PromptManager promptManager)
@@ -104,6 +180,101 @@ public class PromptsActivity extends AppCompatActivity { // Removed PromptsAdapt
         // Handle EDIT_PROMPT_REQUEST if implemented
     }
 
+    private void fetchChatGptModelsAndUpdateSpinner() {
+        if (chatGptApi == null || sharedPreferences.getString("openai_api_key", "").isEmpty()) {
+            android.widget.Toast.makeText(this, "API client not initialized or API Key missing.", android.widget.Toast.LENGTH_LONG).show();
+            return;
+        }
+
+        progressDialog = new ProgressDialog(this);
+        progressDialog.setMessage("Fetching available ChatGPT models...");
+        progressDialog.setCancelable(false);
+        progressDialog.show();
+
+        executorService.execute(() -> {
+            try {
+                final List<OpenAIModelData.ModelInfo> models = chatGptApi.listModels(); // This is a synchronous call
+                mainHandler.post(() -> {
+                    if (progressDialog.isShowing()) {
+                        progressDialog.dismiss();
+                    }
+                    if (models == null || models.isEmpty()) {
+                        android.widget.Toast.makeText(PromptsActivity.this, "No models returned or error fetching.", android.widget.Toast.LENGTH_LONG).show();
+                        return;
+                    }
+
+                    modelListPrompts.clear();
+                    List<String> modelIds = new ArrayList<>();
+                    for (OpenAIModelData.ModelInfo model : models) {
+                        String id = model.getId();
+                        // Basic filtering for text-based models, can be refined
+                        if (id != null && !id.trim().isEmpty() &&
+                            (id.contains("gpt") || id.contains("text-davinci") || id.contains("claude") || id.contains("gemini")) && // Common text model identifiers
+                            !id.contains("vision") && !id.contains("image") && !id.contains("audio") &&
+                            !id.contains("tts") && !id.contains("whisper") && !id.contains("dall-e") &&
+                            !id.contains("embedding") && !id.contains("moderation")) {
+                            modelListPrompts.add(id);
+                            modelIds.add(id);
+                        }
+                    }
+                    Collections.sort(modelListPrompts);
+
+                    if (modelListPrompts.isEmpty()) {
+                        android.widget.Toast.makeText(PromptsActivity.this, "No suitable text-based ChatGPT models found.", android.widget.Toast.LENGTH_LONG).show();
+                    } else {
+                        modelAdapterPrompts.notifyDataSetChanged();
+                        sharedPreferences.edit().putStringSet(PREF_KEY_FETCHED_CHATGPT_MODEL_IDS_PROMPTS, new HashSet<>(modelIds)).apply();
+
+                        String previouslySelectedModel = sharedPreferences.getString(PREF_KEY_SELECTED_CHATGPT_MODEL_PROMPTS, null);
+                        if (previouslySelectedModel != null && modelListPrompts.contains(previouslySelectedModel)) {
+                            spinnerChatGptModels.setSelection(modelListPrompts.indexOf(previouslySelectedModel));
+                        } else if (!modelListPrompts.isEmpty()) {
+                            spinnerChatGptModels.setSelection(0); // Select the first one
+                            sharedPreferences.edit().putString(PREF_KEY_SELECTED_CHATGPT_MODEL_PROMPTS, modelListPrompts.get(0)).apply();
+                             if (chatGptApi != null) chatGptApi.setModel(modelListPrompts.get(0));
+                        }
+                        android.widget.Toast.makeText(PromptsActivity.this, "ChatGPT models updated.", android.widget.Toast.LENGTH_SHORT).show();
+                    }
+                });
+            } catch (Exception e) {
+                Log.e("PromptsActivity", "Failed to fetch models", e);
+                mainHandler.post(() -> {
+                    if (progressDialog != null && progressDialog.isShowing()) {
+                        progressDialog.dismiss();
+                    }
+                    android.widget.Toast.makeText(PromptsActivity.this, "Error fetching models: " + e.getMessage(), android.widget.Toast.LENGTH_LONG).show();
+                });
+            }
+        });
+    }
+
+    private void loadAndPopulateChatGptModelsSpinner() {
+        Set<String> fetchedModelIds = sharedPreferences.getStringSet(PREF_KEY_FETCHED_CHATGPT_MODEL_IDS_PROMPTS, null);
+        modelListPrompts.clear();
+
+        if (fetchedModelIds != null && !fetchedModelIds.isEmpty()) {
+            modelListPrompts.addAll(fetchedModelIds);
+            Collections.sort(modelListPrompts); // Ensure sorted order
+        } else {
+            // Fallback to a minimal default list if nothing is fetched or stored
+            // This could be expanded or loaded from an XML array resource
+            modelListPrompts.add("gpt-4-turbo");
+            modelListPrompts.add("gpt-3.5-turbo");
+        }
+        modelAdapterPrompts.notifyDataSetChanged();
+
+        String selectedModel = sharedPreferences.getString(PREF_KEY_SELECTED_CHATGPT_MODEL_PROMPTS, modelListPrompts.get(0));
+        int selectionIndex = modelListPrompts.indexOf(selectedModel);
+        if (selectionIndex >= 0) {
+            spinnerChatGptModels.setSelection(selectionIndex);
+        } else if (!modelListPrompts.isEmpty()) {
+            spinnerChatGptModels.setSelection(0); // Default to the first item if saved one isn't in the list
+            sharedPreferences.edit().putString(PREF_KEY_SELECTED_CHATGPT_MODEL_PROMPTS, modelListPrompts.get(0)).apply();
+            if (chatGptApi != null) chatGptApi.setModel(modelListPrompts.get(0));
+        }
+    }
+
+
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
@@ -111,5 +282,16 @@ public class PromptsActivity extends AppCompatActivity { // Removed PromptsAdapt
             return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (executorService != null && !executorService.isShutdown()) {
+            executorService.shutdown();
+        }
+        if (progressDialog != null && progressDialog.isShowing()) {
+            progressDialog.dismiss();
+        }
     }
 }

--- a/app/src/main/java/com/drgraff/speakkey/settings/SettingsActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/settings/SettingsActivity.java
@@ -236,6 +236,27 @@ public class SettingsActivity extends AppCompatActivity {
             if (chatGptModelPreference.getEntry() != null) {
                 chatGptModelPreference.setSummary(chatGptModelPreference.getEntry());
             }
+
+            ListPreference transcriptionModePreference = findPreference("transcription_mode");
+            if (transcriptionModePreference != null) {
+                if (transcriptionModePreference.getEntry() != null) {
+                    transcriptionModePreference.setSummary(transcriptionModePreference.getEntry());
+                } else {
+                    // If entry is null (e.g. if value was set programmatically to something not in entryValues)
+                    // you might want to set a default summary or try to find value and set summary accordingly.
+                    // For now, relying on getEntry() is fine as per existing pattern for chatgpt_model.
+                    CharSequence value = transcriptionModePreference.getValue();
+                    int index = transcriptionModePreference.findIndexOfValue(value != null ? value.toString() : "");
+                    if (index >= 0) {
+                        transcriptionModePreference.setSummary(transcriptionModePreference.getEntries()[index]);
+                    } else {
+                         // If the value is not found, you could set a generic summary or the default.
+                         // For simplicity, let's assume the value will be one of the defined ones.
+                         // If using a default value from XML, getEntry() should ideally not be null.
+                        transcriptionModePreference.setSummary("Select transcription service");
+                    }
+                }
+            }
         }
         
         @Override
@@ -260,6 +281,14 @@ public class SettingsActivity extends AppCompatActivity {
                 Preference modelPref = findPreference(key);
                 if (modelPref instanceof ListPreference) {
                     ListPreference listPref = (ListPreference) modelPref;
+                    if (listPref.getEntry() != null) {
+                        listPref.setSummary(listPref.getEntry());
+                    }
+                }
+            } else if (key.equals("transcription_mode")) {
+                Preference pref = findPreference(key);
+                if (pref instanceof ListPreference) {
+                    ListPreference listPref = (ListPreference) pref;
                     if (listPref.getEntry() != null) {
                         listPref.setSummary(listPref.getEntry());
                     }

--- a/app/src/main/res/layout/activity_prompts.xml
+++ b/app/src/main/res/layout/activity_prompts.xml
@@ -23,24 +23,76 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/prompts_recycler_view"
+    <LinearLayout
+        android:id="@+id/content_area_prompts"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        android:padding="8dp"
-        android:clipToPadding="false"
-        tools:listitem="@layout/list_item_prompt"/>
+        android:orientation="vertical"
+        android:padding="16dp"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-    <TextView
-        android:id="@+id/empty_prompts_text_view"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/empty_prompts_text"
-        android:textSize="16sp"
-        android:visibility="gone"
-        android:layout_gravity="center"
-        tools:visibility="visible"/>
+        <!-- Model Selection Section -->
+        <LinearLayout
+            android:id="@+id/model_selection_layout_prompts"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingTop="8dp"
+            android:paddingBottom="8dp"
+            android:layout_marginBottom="8dp"
+            android:background="?attr/colorSurface"
+            android:elevation="2dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Select ChatGPT model for prompt processing:"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:layout_marginBottom="8dp"/>
+
+            <Spinner
+                android:id="@+id/spinner_chatgpt_models_prompts"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:minHeight="48dp"/>
+
+            <Button
+                android:id="@+id/btn_check_chatgpt_models_prompts"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Check Models"
+                android:layout_gravity="end"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="8dp"/>
+        </LinearLayout>
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/prompts_recycler_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="8dp"
+                android:clipToPadding="false"
+                tools:listitem="@layout/list_item_prompt"/>
+
+            <TextView
+                android:id="@+id/empty_prompts_text_view"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/empty_prompts_text"
+                android:textSize="16sp"
+                android:visibility="gone"
+                android:layout_gravity="center"
+                tools:visibility="visible"/>
+        </FrameLayout>
+    </LinearLayout>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab_add_prompt"

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -91,142 +91,143 @@
             android:visibility="invisible" />
     </LinearLayout>
 
-    <!-- Whisper Controls -->
+    <!-- Whisper Section Container -->
     <LinearLayout
-        android:id="@+id/whisper_controls"
+        android:id="@+id/whisper_section_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:gravity="center_horizontal"
-        android:layout_marginTop="2dp"
-        app:layout_constraintTop_toBottomOf="@id/recording_indicator_layout">
-
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:gravity="center_vertical">
-
-            <Button
-                android:id="@+id/btn_send_whisper"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/send_to_whisper"
-                android:layout_marginEnd="8dp"/> <!-- Adjust margin as needed -->
-
-            <CheckBox
-                android:id="@+id/chk_auto_send_whisper"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Auto-send"/>
-
-            <ImageButton
-                android:id="@+id/btn_clear_all_whisper_icon"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@android:drawable/ic_menu_delete"
-                android:contentDescription="@string/clear_all_content_description"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:padding="4dp"
-                android:layout_marginStart="8dp"/>
-        </LinearLayout>
-    </LinearLayout>
-
-    <!-- Whisper Section -->
-    <TextView
-        android:id="@+id/whisper_label"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Whisper Transcription"
-        android:layout_marginTop="4dp"
-        android:textStyle="bold"
-        app:layout_constraintTop_toBottomOf="@id/whisper_controls"
-        app:layout_constraintStart_toStartOf="parent" />
-
-    <LinearLayout
-        android:id="@+id/whisper_text_container"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:layout_marginTop="0dp"
-        android:layout_marginBottom="2dp"
-        app:layout_constraintTop_toBottomOf="@id/whisper_label"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/whisper_to_inputstick_controls">
-
-        <EditText
-            android:id="@+id/whisper_text"
-            android:layout_width="0dp"
-            android:layout_height="180dp"
-            android:layout_weight="1"
-            android:background="@color/edit_text_background"
-            android:hint="Transcribed text will appear here"
-            android:padding="8dp"
-            android:gravity="top|start"
-            android:inputType="textMultiLine"
-            android:drawableEnd="?android:attr/actionModeWebSearchDrawable"
-            android:focusable="false"
-            android:clickable="true"
-            android:scrollbars="vertical"
-            android:fadeScrollbars="false"
-            android:nestedScrollingEnabled="true"
-            android:minLines="3"
-            android:maxLines="100"/>
-
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:layout_marginStart="4dp">
-
-            <ImageButton
-                android:id="@+id/btn_clear_transcription_icon"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@android:drawable/ic_menu_delete"
-                android:contentDescription="@string/clear_transcription"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:padding="8dp"/>
-
-            <ImageButton
-                android:id="@+id/btn_share_whisper_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@android:drawable/ic_menu_share"
-                android:contentDescription="@string/main_btn_share_whisper_desc"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:padding="8dp"/>
-        </LinearLayout>
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/whisper_to_inputstick_controls"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:gravity="center"
-        android:layout_marginTop="2dp"
-        android:layout_marginBottom="0dp"
-        app:layout_constraintTop_toBottomOf="@id/whisper_text"
+        app:layout_constraintTop_toBottomOf="@id/recording_indicator_layout"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toTopOf="@+id/active_prompts_display">
-        <!-- The Button @+id/btn_clear_transcription was here. 
-             The bottom constraint of whisper_to_inputstick_controls needs to point to chatgpt_controls -->
 
-        <Button
-            android:id="@+id/btn_send_whisper_to_inputstick"
+        <!-- Whisper Controls -->
+        <LinearLayout
+            android:id="@+id/whisper_controls"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center_horizontal"
+            android:layout_marginTop="2dp">
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <Button
+                    android:id="@+id/btn_send_whisper"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/send_to_whisper"
+                    android:layout_marginEnd="8dp"/> <!-- Adjust margin as needed -->
+
+                <CheckBox
+                    android:id="@+id/chk_auto_send_whisper"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Auto-send"/>
+
+                <ImageButton
+                    android:id="@+id/btn_clear_all_whisper_icon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@android:drawable/ic_menu_delete"
+                    android:contentDescription="@string/clear_all_content_description"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:padding="4dp"
+                    android:layout_marginStart="8dp"/>
+            </LinearLayout>
+        </LinearLayout>
+
+        <!-- Whisper Section Label -->
+        <TextView
+            android:id="@+id/whisper_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="SEND TO INPUTSTICK"
-            android:layout_marginEnd="8dp"/>
+            android:text="Whisper Transcription"
+            android:layout_marginTop="4dp"
+            android:textStyle="bold" />
 
-        <CheckBox
-            android:id="@+id/chk_auto_send_whisper_to_inputstick"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:id="@+id/whisper_text_container"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Auto-send"/>
+            android:orientation="horizontal"
+            android:layout_marginTop="0dp"
+            android:layout_marginBottom="2dp">
+
+            <EditText
+                android:id="@+id/whisper_text"
+                android:layout_width="0dp"
+                android:layout_height="180dp"
+                android:layout_weight="1"
+                android:background="@color/edit_text_background"
+                android:hint="Transcribed text will appear here"
+                android:padding="8dp"
+                android:gravity="top|start"
+                android:inputType="textMultiLine"
+                android:drawableEnd="?android:attr/actionModeWebSearchDrawable"
+                android:focusable="false"
+                android:clickable="true"
+                android:scrollbars="vertical"
+                android:fadeScrollbars="false"
+                android:nestedScrollingEnabled="true"
+                android:minLines="3"
+                android:maxLines="100"/>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginStart="4dp">
+
+                <ImageButton
+                    android:id="@+id/btn_clear_transcription_icon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@android:drawable/ic_menu_delete"
+                    android:contentDescription="@string/clear_transcription"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:padding="8dp"/>
+
+                <ImageButton
+                    android:id="@+id/btn_share_whisper_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@android:drawable/ic_menu_share"
+                    android:contentDescription="@string/main_btn_share_whisper_desc"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:padding="8dp"/>
+            </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/whisper_to_inputstick_controls"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center"
+            android:layout_marginTop="2dp"
+            android:layout_marginBottom="0dp">
+            <!-- The Button @+id/btn_clear_transcription was here.
+                 The bottom constraint of whisper_to_inputstick_controls needs to point to chatgpt_controls -->
+
+            <Button
+                android:id="@+id/btn_send_whisper_to_inputstick"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="SEND TO INPUTSTICK"
+                android:layout_marginEnd="8dp"/>
+
+            <CheckBox
+                android:id="@+id/chk_auto_send_whisper_to_inputstick"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Auto-send"/>
+        </LinearLayout>
     </LinearLayout>
 
     <TextView
@@ -243,7 +244,7 @@
         android:clickable="true"
         android:focusable="true"
         android:background="?attr/selectableItemBackground"
-        app:layout_constraintTop_toBottomOf="@id/whisper_to_inputstick_controls"
+        app:layout_constraintTop_toBottomOf="@id/whisper_section_container"
         app:layout_constraintBottom_toTopOf="@id/chatgpt_controls"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -35,4 +35,13 @@
         <item>ja</item>
         <item>zh</item>
     </string-array>
+
+    <string-array name="transcription_mode_entries">
+        <item>Whisper</item>
+        <item>ChatGPT Direct</item>
+    </string-array>
+    <string-array name="transcription_mode_values">
+        <item>whisper</item>
+        <item>chatgpt_direct</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -29,6 +29,14 @@
             android:defaultValue="https://api.openai.com/v1/audio/transcriptions" />
 
         <ListPreference
+            android:key="transcription_mode"
+            android:title="Transcription Mode"
+            android:summary="Select the transcription service to use."
+            android:defaultValue="whisper"
+            android:entries="@array/transcription_mode_entries"
+            android:entryValues="@array/transcription_mode_values" />
+
+        <ListPreference
             android:key="language"
             android:title="@string/settings_language_title"
             android:summary="@string/settings_language_summary"


### PR DESCRIPTION
…ity UI

This commit introduces a new feature allowing you to select your preferred transcription mode:
- "Whisper": Uses the existing flow (Record -> Whisper -> ChatGPT for processing).
- "ChatGPT Direct": Records audio and sends it directly to an OpenAI API endpoint (currently Whisper API via ChatGptApi) for transcription. The transcription appears in the main ChatGPT response box.

Key changes:

1.  **Settings:**
    - Added a "Transcription Mode" preference in settings ("whisper" or "chatgpt_direct").

2.  **MainActivity:**
    - UI dynamically changes based on the selected transcription mode, hiding/showing the Whisper-specific section.
    - "Active Prompts" display shows "Direct Transcription" in ChatGPT Direct mode if no prompts are selected.
    - Recording logic now routes to either Whisper (via UploadService) or direct ChatGPT/Whisper transcription based on the mode.
    - The "Send to ChatGPT" button in "ChatGPT Direct" mode re-sends the last recorded audio with current prompts.
    - Updated clearing logic to handle the new audio path variable for direct mode.

3.  **PromptsActivity:**
    - UI updated to include a ChatGPT model selection spinner and "Check Models" button at the top, similar to PhotoPromptsActivity.
    - Logic added to fetch, display, and save general text-based ChatGPT models.

4.  **ChatGptApi:**
    - Added `getTranscriptionFromAudio()` method to send audio directly to the OpenAI `/v1/audio/transcriptions` endpoint (using "whisper-1" model).
    - Refactored `OkHttpClient` to use a shared instance.
    - Added `setModel()` method to allow changing the text-generation model post-instantiation.

The changes provide you with more flexibility in how your audio is processed, allowing for direct transcription when advanced prompt processing via a separate ChatGPT step is not required.