### PR TITLE
feat: Implement selectable transcription mode and update PromptsActiv…

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/data/UploadTask.java
+++ b/app/src/main/java/com/drgraff/speakkey/data/UploadTask.java
@@ -1,6 +1,7 @@
 package com.drgraff.speakkey.data;
 
 import androidx.room.Entity;
+import androidx.room.Ignore; // Added
 import androidx.room.PrimaryKey;
 
 @Entity(tableName = "upload_tasks")
@@ -46,6 +47,7 @@ public class UploadTask {
     }
 
     // Constructor for Audio Transcription
+    @Ignore // Added
     public UploadTask(String filePath, String uploadType, boolean isAudio) {
         this(filePath, uploadType); // Calls the main constructor
         if (!isAudio) {
@@ -55,6 +57,7 @@ public class UploadTask {
     }
 
     // Constructor for Photo Vision
+    @Ignore // Added
     public UploadTask(String filePath, String uploadType, String promptText, String modelName) {
         this(filePath, uploadType); // Calls the main constructor
         this.promptText = promptText;


### PR DESCRIPTION
…ity UI

This commit introduces a new feature allowing you to select your preferred transcription mode:
- "Whisper": Uses the existing flow (Record -> Whisper -> ChatGPT for processing).
- "ChatGPT Direct": Records audio and sends it directly to an OpenAI API endpoint (currently Whisper API via ChatGptApi) for transcription. The transcription appears in the main ChatGPT response box.

Key changes:

1.  **Settings:**
    - Added a "Transcription Mode" preference in settings ("whisper" or "chatgpt_direct").

2.  **MainActivity:**
    - UI dynamically changes based on the selected transcription mode, hiding/showing the Whisper-specific section.
    - "Active Prompts" display shows "Direct Transcription" in ChatGPT Direct mode if no prompts are selected.
    - Recording logic now routes to either Whisper (via UploadService) or direct ChatGPT/Whisper transcription based on the mode.
    - The "Send to ChatGPT" button in "ChatGPT Direct" mode re-sends the last recorded audio with current prompts.
    - Updated clearing logic to handle the new audio path variable for direct mode.

3.  **PromptsActivity:**
    - UI updated to include a ChatGPT model selection spinner and "Check Models" button at the top, similar to PhotoPromptsActivity.
    - Logic added to fetch, display, and save general text-based ChatGPT models.

4.  **ChatGptApi:**
    - Added `getTranscriptionFromAudio()` method to send audio directly to the OpenAI `/v1/audio/transcriptions` endpoint (using "whisper-1" model).
    - Refactored `OkHttpClient` to use a shared instance.
    - Added `setModel()` method to allow changing the text-generation model post-instantiation.

The changes provide you with more flexibility in how your audio is processed, allowing for direct transcription when advanced prompt processing via a separate ChatGPT step is not required.