### PR TITLE
feat: Implement selectable transcription mode and update PromptsActiv…

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -78,7 +78,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     private Button btnSendWhisper; // Removed btnClearTranscription, Removed btnClearRecording
     private ImageButton btnClearTranscriptionIcon; // Added
     private ImageButton btnClearAllWhisperIcon; // Added to replace btnClearAll
-    private Button btnRefreshStatus; // Added for manual refresh
+    // private Button btnRefreshStatus; // Removed
     private Button btnSendChatGpt; // Removed btnClearChatGpt
     private ImageButton btnClearChatGptIcon; // Added
     private Button btnSendInputStick;
@@ -282,7 +282,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         // chkAutoSendInputStick.setChecked(sharedPreferences.getBoolean("auto_send_inputstick", false)); // Moved down
         // chkAutoSendToChatGpt.setChecked(sharedPreferences.getBoolean("auto_send_to_chatgpt", false)); // Moved down
         // chk_auto_send_whisper_to_inputstick.setChecked(sharedPreferences.getBoolean("auto_send_whisper_to_inputstick", false)); // Moved down
-        btnRefreshStatus = findViewById(R.id.btn_refresh_status); // Initialize refresh button
+        // btnRefreshStatus = findViewById(R.id.btn_refresh_status); // Removed
         whisperSectionContainer = findViewById(R.id.whisper_section_container); // Added
 
         setupClickListeners(); // Moved to after all findViewById calls
@@ -362,9 +362,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             btnClearTranscriptionIcon.setOnClickListener(v -> clearTranscription());
         }
 
-        if (btnRefreshStatus != null) {
-            btnRefreshStatus.setOnClickListener(v -> refreshTranscriptionStatus(true)); // true for user initiated
-        }
+        // if (btnRefreshStatus != null) { // Removed
+        //     btnRefreshStatus.setOnClickListener(v -> refreshTranscriptionStatus(true)); // true for user initiated
+        // }
         
         btnSendChatGpt.setOnClickListener(v -> sendToChatGpt());
         // btnClearChatGpt.setOnClickListener(v -> clearChatGptResponse()); // Removed old listener

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,7 @@
     
     <!-- Errors -->
     <string name="error_no_api_key">Please set your OpenAI API key in Settings</string>
+    <string name="api_key_not_set_short">API Key Not Set</string> <!-- Added -->
     <string name="error_recording">Error while recording audio</string>
     <string name="error_transcribing">Error transcribing audio</string>
     <string name="error_chatgpt">Error getting response from ChatGPT</string>


### PR DESCRIPTION
…ity UI

This commit introduces a new feature allowing you to select your preferred transcription mode:
- "Whisper": Uses the existing flow (Record -> Whisper -> ChatGPT for processing).
- "ChatGPT Direct": Records audio and sends it directly to an OpenAI API endpoint (currently Whisper API via ChatGptApi) for transcription. The transcription appears in the main ChatGPT response box.

Key changes:

1.  **Settings:**
    - Added a "Transcription Mode" preference in settings ("whisper" or "chatgpt_direct").

2.  **MainActivity:**
    - UI dynamically changes based on the selected transcription mode, hiding/showing the Whisper-specific section.
    - "Active Prompts" display shows "Direct Transcription" in ChatGPT Direct mode if no prompts are selected.
    - Recording logic now routes to either Whisper (via UploadService) or direct ChatGPT/Whisper transcription based on the mode.
    - The "Send to ChatGPT" button in "ChatGPT Direct" mode re-sends the last recorded audio with current prompts.
    - Updated clearing logic to handle the new audio path variable for direct mode.

3.  **PromptsActivity:**
    - UI updated to include a ChatGPT model selection spinner and "Check Models" button at the top, similar to PhotoPromptsActivity.
    - Logic added to fetch, display, and save general text-based ChatGPT models.

4.  **ChatGptApi:**
    - Added `getTranscriptionFromAudio()` method to send audio directly to the OpenAI `/v1/audio/transcriptions` endpoint (using "whisper-1" model).
    - Refactored `OkHttpClient` to use a shared instance.
    - Added `setModel()` method to allow changing the text-generation model post-instantiation.

The changes provide you with more flexibility in how your audio is processed, allowing for direct transcription when advanced prompt processing via a separate ChatGPT step is not required.