### PR TITLE
fix: Standardize on M4A audio format to resolve API errors

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/api/ChatGptApi.java
+++ b/app/src/main/java/com/drgraff/speakkey/api/ChatGptApi.java
@@ -222,7 +222,10 @@ public class ChatGptApi {
 
         Log.d(TAG, "Sending audio transcription request. Model: " + modelName + ", Prompt: " + userPrompt);
 
-        RequestBody fileBody = RequestBody.create(audioFile, MediaType.parse("audio/mpeg")); // Adjust MediaType if necessary
+        String whisperFileMimeType = "audio/m4a"; // Assuming m4a from now on
+        if (audioFile.getName().toLowerCase().endsWith(".mp3")) whisperFileMimeType = "audio/mpeg";
+        // Add other types if MainActivity might produce them for Whisper mode in the future
+        RequestBody fileBody = RequestBody.create(audioFile, MediaType.parse(whisperFileMimeType));
 
         MultipartBody.Builder requestBodyBuilder = new MultipartBody.Builder()
                 .setType(MultipartBody.FORM)
@@ -293,9 +296,24 @@ public class ChatGptApi {
 
         String base64Audio = encodeAudioToBase64(audioFile);
 
-        String audioFileFormat = "wav"; // Default, determine from file if possible
+        String audioFileFormat = "m4a"; // New default or ensure it's detected
         String fileNameLower = audioFile.getName().toLowerCase();
-        if (fileNameLower.endsWith(".mp3")) audioFileFormat = "mp3";
+        if (fileNameLower.endsWith(".mp3")) {
+            audioFileFormat = "mp3";
+        } else if (fileNameLower.endsWith(".m4a")) {
+            audioFileFormat = "m4a";
+        } else if (fileNameLower.endsWith(".wav")) {
+            audioFileFormat = "wav";
+        } else if (fileNameLower.endsWith(".ogg")) {
+            audioFileFormat = "ogg";
+        } else if (fileNameLower.endsWith(".flac")) {
+            audioFileFormat = "flac";
+        }
+        Log.d(TAG, "Determined audioFileFormat: " + audioFileFormat + " for file: " + fileNameLower);
+        // Add more formats as supported by the model
+
+
+        JSONObject payload = new JSONObject();
         else if (fileNameLower.endsWith(".m4a")) audioFileFormat = "m4a";
         else if (fileNameLower.endsWith(".ogg")) audioFileFormat = "ogg";
         else if (fileNameLower.endsWith(".flac")) audioFileFormat = "flac";


### PR DESCRIPTION
Changes the audio recording format from a mislabeled MP3 to M4A (AAC in an MP4 container) to accurately represent the data produced by MediaRecorder and to fix "invalid mp3 format" errors from the OpenAI API.

1.  **MainActivity.java:**
    - Audio recordings are now saved with the `.m4a` extension.
    - MediaRecorder settings (OutputFormat.MPEG_4, AudioEncoder.AAC) remain as they correctly produce M4A content.

2.  **ChatGptApi.java:**
    - In `getCompletionFromAudioAndPrompt` (for gpt-4o style calls), the `audioFileFormat` sent in the JSON payload now correctly defaults to/detects "m4a".
    - In `getTranscriptionFromAudio` (for Whisper API calls), the `MediaType` for the file part in the multipart request now correctly defaults to "audio/m4a" (or "audio/mpeg" if an .mp3 file is somehow provided).

This ensures that the audio format declared to the OpenAI API matches the actual content of the audio file, resolving previous format validation errors.