### PR TITLE
I've corrected a syntax error in your `ChatGptApi.java` file.

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/api/ChatGptApi.java
+++ b/app/src/main/java/com/drgraff/speakkey/api/ChatGptApi.java
@@ -314,13 +314,6 @@ public class ChatGptApi {
 
 
         JSONObject payload = new JSONObject();
-        else if (fileNameLower.endsWith(".m4a")) audioFileFormat = "m4a";
-        else if (fileNameLower.endsWith(".ogg")) audioFileFormat = "ogg";
-        else if (fileNameLower.endsWith(".flac")) audioFileFormat = "flac";
-        // Add more formats as supported by the model
-
-
-        JSONObject payload = new JSONObject();
         try {
             payload.put("model", modelName); // e.g., "gpt-4o-audio-preview"
 


### PR DESCRIPTION
I removed a duplicated block of code (if/else if statements for audioFileFormat detection and a JSONObject payload initialization) within the `getCompletionFromAudioAndPrompt` method. This resolved an 'else without if' syntax error.