### PR TITLE
feat: Configure MP3 recording and API handling for dual modes

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -163,10 +163,10 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         if (!audioDir.exists()) {
             audioDir.mkdirs();
         }
-        // audioFilePath = new File(audioDir, "recording.mp3").getAbsolutePath();
-        // Log.i(TAG, "MainActivity.onCreate: audioFilePath set to MP3: " + audioFilePath);
-        audioFilePath = new File(audioDir, "recording.m4a").getAbsolutePath();
-        Log.i(TAG, "MainActivity.onCreate: audioFilePath set to M4A: " + audioFilePath);
+        // audioFilePath = new File(audioDir, "recording.m4a").getAbsolutePath();
+        // Log.i(TAG, "MainActivity.onCreate: audioFilePath set to M4A: " + audioFilePath);
+        audioFilePath = new File(audioDir, "recording.mp3").getAbsolutePath();
+        Log.i(TAG, "FINAL_MP3_PATH_ATTEMPT: audioFilePath set to MP3: " + audioFilePath);
 
 
         // Display active macros
@@ -492,12 +492,12 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         try {
             mediaRecorder = new MediaRecorder();
             mediaRecorder.setAudioSource(MediaRecorder.AudioSource.MIC);
-            mediaRecorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
-            mediaRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC); // Use AAC for M4A
+            mediaRecorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4); // Container
+            mediaRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.MP3);   // MP3 Encoder (Requires API 29+)
             mediaRecorder.setAudioSamplingRate(16000);
             mediaRecorder.setAudioChannels(1);
-            // mediaRecorder.setAudioEncodingBitRate(96000); // Optional for AAC
-            Log.i(TAG, "MainActivity.startRecording: Configured for M4A (AAC).");
+            mediaRecorder.setAudioEncodingBitRate(96000); // 96 kbps
+            Log.i(TAG, "FINAL_MP3_RECORDER_ATTEMPT: OutputFormat=MPEG_4, AudioEncoder=MP3");
             mediaRecorder.setOutputFile(audioFilePath);
             mediaRecorder.prepare();
             mediaRecorder.start();
@@ -693,7 +693,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             // Do NOT automatically call sendToChatGpt or sendWhisperToInputStick here anymore.
             // That logic will move to when the task is actually completed by the service.
         });
-        Log.i(TAG, "MainActivity.transcribeAudio: Queued M4A for Whisper transcription.");
+        Log.i(TAG, "MainActivity.transcribeAudio: Queued MP3 for Whisper transcription via UploadService.");
     }
 
     private void refreshTranscriptionStatus(boolean userInitiated) {
@@ -806,15 +806,15 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         final String modelName = sharedPreferences.getString("chatgpt_model", "gpt-4o-audio-preview"); // Ensure this model supports audio input
 
         mainHandler.post(() -> {
-            chatGptText.setText("[DIRECT_MODE: Sending M4A audio & prompt to " + modelName + "...]");
+            chatGptText.setText("[DIRECT_MODE: Sending MP3 audio & prompt to " + modelName + "...]");
             Toast.makeText(MainActivity.this, "DIRECT_MODE: Processing with " + modelName + "...", Toast.LENGTH_SHORT).show();
         });
-        AppLogManager.getInstance().addEntry("INFO", TAG + ": M4A_SINGLE_CALL to getCompletionFromAudioAndPrompt.", "Model: " + modelName + ", Audio: " + currentAudioFile.getName());
+        AppLogManager.getInstance().addEntry("INFO", TAG + ": DIRECT_MODE: Calling getCompletionFromAudioAndPrompt with MP3.", "Model: " + modelName + ", Audio: " + currentAudioFile.getName());
 
         new Thread(() -> {
             try {
                 final String result = chatGptApi.getCompletionFromAudioAndPrompt(currentAudioFile, finalUserPrompt, modelName);
-                AppLogManager.getInstance().addEntry("SUCCESS", TAG + ": M4A_SINGLE_CALL: Response from " + modelName + " received.", "Output Length: " + (result != null ? result.length() : "null"));
+                AppLogManager.getInstance().addEntry("SUCCESS", TAG + ": DIRECT_MODE: Response from " + modelName + " received.", "Output Length: " + (result != null ? result.length() : "null"));
                 mainHandler.post(() -> {
                     chatGptText.setText(result);
                     Toast.makeText(MainActivity.this, "DIRECT_MODE: " + modelName + " processing complete.", Toast.LENGTH_SHORT).show();
@@ -823,15 +823,15 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                     }
                 });
             } catch (IOException e) {
-                Log.e(TAG, "M4A_SINGLE_CALL: IOException during " + modelName + " processing: " + e.getMessage(), e);
-                AppLogManager.getInstance().addEntry("ERROR", TAG + ": M4A_SINGLE_CALL: IOException in " + modelName + " processing.", "Error: " + e.getMessage());
+                Log.e(TAG, "DIRECT_MODE: IOException during " + modelName + " processing: " + e.getMessage(), e);
+                AppLogManager.getInstance().addEntry("ERROR", TAG + ": DIRECT_MODE: IOException in " + modelName + " processing.", "Error: " + e.getMessage());
                 mainHandler.post(() -> {
                     chatGptText.setText("[DIRECT_MODE: API Error (" + modelName + "): " + e.getMessage() + "]");
                     Toast.makeText(MainActivity.this, "DIRECT_MODE: API Error - " + e.getMessage(), Toast.LENGTH_LONG).show();
                 });
             } catch (Exception e) {
-                Log.e(TAG, "M4A_SINGLE_CALL: Unexpected error during " + modelName + " processing: " + e.getMessage(), e);
-                AppLogManager.getInstance().addEntry("ERROR", TAG + ": M4A_SINGLE_CALL: Unexpected error in " + modelName + " processing.", "Error: " + e.toString());
+                Log.e(TAG, "DIRECT_MODE: Unexpected error during " + modelName + " processing: " + e.getMessage(), e);
+                AppLogManager.getInstance().addEntry("ERROR", TAG + ": DIRECT_MODE: Unexpected error in " + modelName + " processing.", "Error: " + e.toString());
                 mainHandler.post(() -> {
                     chatGptText.setText("[DIRECT_MODE: Unexpected error with " + modelName + "]");
                     Toast.makeText(MainActivity.this, "DIRECT_MODE: Unexpected error (" + modelName + ")", Toast.LENGTH_LONG).show();
@@ -846,11 +846,11 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
         if (transcriptionMode.equals("chatgpt_direct")) {
             if (lastRecordedAudioPathForChatGPTDirect != null && new File(lastRecordedAudioPathForChatGPTDirect).exists()) {
-                Log.d(TAG, "sendToChatGpt (Direct Mode): Calling transcribeAudioWithChatGpt for M4A file " + lastRecordedAudioPathForChatGPTDirect);
-                transcribeAudioWithChatGpt(); // This will use the M4A and call getCompletionFromAudioAndPrompt
+                Log.d(TAG, "sendToChatGpt (Direct Mode): Calling transcribeAudioWithChatGpt for MP3 file " + lastRecordedAudioPathForChatGPTDirect);
+                transcribeAudioWithChatGpt(); // This will use the MP3 and call getCompletionFromAudioAndPrompt
             } else {
                 Toast.makeText(this, "Please record audio first for direct processing.", Toast.LENGTH_LONG).show();
-                AppLogManager.getInstance().addEntry("WARN", TAG + ": sendToChatGpt (Direct Mode) called but no valid M4A audio path.", "lastRecordedAudioPathForChatGPTDirect: " + lastRecordedAudioPathForChatGPTDirect);
+                AppLogManager.getInstance().addEntry("WARN", TAG + ": sendToChatGpt (Direct Mode) called but no valid MP3 audio path.", "lastRecordedAudioPathForChatGPTDirect: " + lastRecordedAudioPathForChatGPTDirect);
             }
         } else { // "whisper" mode (two-step: `whisperText` should ideally have transcription from UploadService)
             String transcript = whisperText.getText().toString().trim();
@@ -878,7 +878,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                 chatGptText.setText("[WHISPER_MODE: Sending text to " + currentChatGptModel + "...]");
                 Toast.makeText(MainActivity.this, "WHISPER_MODE: Sending to " + currentChatGptModel + "...", Toast.LENGTH_SHORT).show();
             });
-            AppLogManager.getInstance().addEntry("INFO", TAG + ": M4A_WHISPER_MODE_SEND_TO_CHATGPT", "Model: " + currentChatGptModel + ", Payload Length: " + finalTextPayload.length());
+            AppLogManager.getInstance().addEntry("INFO", TAG + ": MP3_WHISPER_MODE_SEND_TO_CHATGPT", "Model: " + currentChatGptModel + ", Payload Length: " + finalTextPayload.length());
 
             new Thread(() -> {
                 try {

--- a/app/src/main/java/com/drgraff/speakkey/api/ChatGptApi.java
+++ b/app/src/main/java/com/drgraff/speakkey/api/ChatGptApi.java
@@ -229,19 +229,17 @@ public class ChatGptApi {
         String whisperFileMimeType;
         String lowerName = audioFile.getName().toLowerCase();
 
-        if (lowerName.equals("recording.m4a")) { // Prioritize this case
-            whisperFileMimeType = "audio/m4a";
-        } else if (lowerName.endsWith(".m4a")) { // General .m4a check
-            whisperFileMimeType = "audio/m4a";
-        } else if (lowerName.endsWith(".mp3")) {
+        if (lowerName.endsWith(".mp3")) {
             whisperFileMimeType = "audio/mpeg";
+        } else if (lowerName.endsWith(".m4a")) {
+            whisperFileMimeType = "audio/m4a";
         } else if (lowerName.endsWith(".wav")) {
             whisperFileMimeType = "audio/wav";
         } else {
-            whisperFileMimeType = "audio/m4a"; // Default if extension is unknown
-            Log.w(TAG, "Unknown audio file extension for Whisper: " + lowerName + ". Defaulting to audio/m4a MIME type.");
+            whisperFileMimeType = "audio/mpeg"; // Default for this attempt
+            Log.w(TAG, "Unknown audio extension for Whisper, defaulting to audio/mpeg: " + lowerName);
         }
-        Log.i(TAG, "WHISPER_MIME_CHECK: Using MIME type: " + whisperFileMimeType + " for file: " + lowerName);
+        Log.i(TAG, "FINAL_MP3_WHISPER_MIME_CHECK: Using MIME type: " + whisperFileMimeType + " for file: " + lowerName);
         RequestBody fileBody = RequestBody.create(audioFile, MediaType.parse(whisperFileMimeType));
 
         MultipartBody.Builder requestBodyBuilder = new MultipartBody.Builder()
@@ -316,12 +314,10 @@ public class ChatGptApi {
         String audioFileFormat;
         String fileNameLower = audioFile.getName().toLowerCase();
 
-        if (fileNameLower.equals("recording.m4a")) { // Prioritize this case
-            audioFileFormat = "m4a";
-        } else if (fileNameLower.endsWith(".m4a")) { // General .m4a check
-            audioFileFormat = "m4a";
-        } else if (fileNameLower.endsWith(".mp3")) {
+        if (fileNameLower.endsWith(".mp3")) {
             audioFileFormat = "mp3";
+        } else if (fileNameLower.endsWith(".m4a")) {
+            audioFileFormat = "m4a";
         } else if (fileNameLower.endsWith(".wav")) {
             audioFileFormat = "wav";
         } else if (fileNameLower.endsWith(".ogg")) {
@@ -329,10 +325,10 @@ public class ChatGptApi {
         } else if (fileNameLower.endsWith(".flac")) {
             audioFileFormat = "flac";
         } else {
-            audioFileFormat = "m4a"; // Default if extension is unknown or different
-            Log.w(TAG, "Unknown audio file extension for getCompletionFromAudioAndPrompt: " + fileNameLower + ". Defaulting to m4a format for API.");
+            audioFileFormat = "mp3"; // Default for this attempt
+            Log.w(TAG, "Unknown audio extension, defaulting to mp3: " + fileNameLower);
         }
-        Log.i(TAG, "AUDIO_FORMAT_API_CHECK: Using audioFileFormat: " + audioFileFormat + " for file: " + fileNameLower);
+        Log.i(TAG, "FINAL_MP3_API_FORMAT_CHECK: Using audioFileFormat: " + audioFileFormat + " in getCompletionFromAudioAndPrompt");
 
 
         JSONObject payload = new JSONObject();


### PR DESCRIPTION
Updates audio processing to use MP3 format as per your request, contingent on MediaRecorder.AudioEncoder.MP3 compiling successfully in your build environment (minSdkVersion 29 is set).

1.  **MainActivity.java:**
    - Audio recordings are saved as `recording.mp3`.
    - MediaRecorder is configured for MP3 output:
        - OutputFormat: MPEG_4
        - AudioEncoder: MP3 (requires API 29+) - Sample Rate: 16kHz, Channels: 1 (Mono), Bitrate: 96kbps
    - `transcription_mode` logic updated: - "whisper" mode: Uses two-step process (MP3 to Whisper API via UploadService for transcription, then text+prompts to Chat API). - "chatgpt_direct" mode: Uses single-step process (MP3 audio + prompts directly to gpt-4o via ChatGptApi.getCompletionFromAudioAndPrompt).

2.  **ChatGptApi.java:**
    - `getCompletionFromAudioAndPrompt` (for gpt-4o JSON calls): Declares `format: "mp3"` in the JSON payload for .mp3 files.
    - `getTranscriptionFromAudio` (for Whisper multipart calls): Sets MIME type to `audio/mpeg` for .mp3 files.
    - `getModel()` method is present.