### PR TITLE
Feature: Set default prompt for Direct Transcription mode

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -912,7 +912,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         List<Prompt> activePrompts = promptManager.getPrompts().stream().filter(Prompt::isActive).collect(Collectors.toList());
         String userPrompt = activePrompts.stream().map(Prompt::getText).collect(Collectors.joining("\n\n"));
         if (userPrompt.isEmpty()) {
-            userPrompt = "Process the audio. If speech, transcribe. If music/noise, describe."; // Default prompt
+            userPrompt = "Please transcribe the audio file.  Do not add anything else before or after the transcribed text."; // Default prompt
         }
         final String finalUserPrompt = userPrompt;
         final String modelName = sharedPreferences.getString("chatgpt_model", "gpt-4o-audio-preview"); // Ensure this model supports audio input


### PR DESCRIPTION
This commit updates the default prompt used in the "ChatGPT Direct" transcription mode when no user-defined prompts are active.

Previously, the default prompt was "Process the audio. If speech, transcribe. If music/noise, describe."

The new default prompt is now:
"Please transcribe the audio file.  Do not add anything else before or after the transcribed text."

This change ensures that when "Direct Transcription" is displayed (indicating no active user prompts for this mode), the API is explicitly instructed to perform a straightforward transcription of the audio.