### PR TITLE
Input:

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -182,8 +182,8 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
 
         // Display active macros
-        displayActiveMacros(); // Call after macroRepository is initialized
         updateUiForTranscriptionMode(transcriptionMode); // Added
+        displayActiveMacros(); // Call after macroRepository is initialized
     }
 
     private void updateUiForTranscriptionMode(String mode) {
@@ -1104,10 +1104,10 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         chk_auto_send_whisper_to_inputstick.setChecked(sharedPreferences.getBoolean("auto_send_whisper_to_inputstick", false)); // Added
 
         // Refresh active macros
-        displayActiveMacros();
         String transcriptionMode = sharedPreferences.getString("transcription_mode", "whisper"); // Added
         updateUiForTranscriptionMode(transcriptionMode); // Added
         updateActivePromptsDisplay(); // Ensure this is called AFTER updateUiForTranscriptionMode
+        displayActiveMacros(); // Moved here
         refreshTranscriptionStatus(false); // false because it's an automatic refresh onResume
     }
 


### PR DESCRIPTION
UI: Adjust UI update order for macro button visibility

This commit reorders method calls in `onCreate()` and `onResume()` of `MainActivity.java`. The `displayActiveMacros()` method is now called after `updateUiForTranscriptionMode()` and `updateActivePromptsDisplay()`.

The intention is to allow `displayActiveMacros()` to set the final visibility state of the macro buttons' container after other UI elements (like the Whisper-specific section) have had their visibility updated based on the current transcription mode.

This change attempts to address an issue where macro buttons might have been inconsistently displayed when switching between "Whisper" and "ChatGPT Direct" transcription modes.

Note: The effectiveness of this change in making macros always visible (if they exist) across all modes depends on the `active_macros_rows_container` not being a child of a view that is explicitly hidden in one of the modes (e.g., not inside `whisperSectionContainer` if that's hidden for "ChatGPT Direct" mode). If such nesting exists in the XML layout, this Java-only change may not be sufficient to override the parent's visibility.

Output:
I've made some adjustments to the UI update order for macro button visibility.

This involves reordering method calls in `onCreate()` and `onResume()` of `MainActivity.java`. Specifically, `displayActiveMacros()` will now be called after `updateUiForTranscriptionMode()` and `updateActivePromptsDisplay()`.

The goal here is to let `displayActiveMacros()` determine the final visibility of the macro buttons' container after other UI elements have updated based on the current transcription mode. This should help with an issue where macro buttons might have been inconsistently displayed when you switched between "Whisper" and "ChatGPT Direct" transcription modes.

Just a heads-up: for this change to ensure macros are always visible (if they exist) across all modes, the `active_macros_rows_container` shouldn't be nested within a view that gets hidden in certain modes (for example, not inside `whisperSectionContainer` if that's hidden for "ChatGPT Direct" mode). If that kind of nesting is present in your XML layout, this Java-only modification might not be enough to override the parent's visibility.