### PR TITLE
Fix: Attempt to correct macro container height in ChatGPT Direct mode

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -17,6 +17,7 @@ import android.view.MenuInflater; // ADD THIS
 import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewGroup; // Added import
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
@@ -1259,6 +1260,17 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                 emptyView.setLayoutParams(params);
                 currentRow.addView(emptyView);
             }
+        }
+
+        // Attempt to force WRAP_CONTENT for height after buttons are added
+        ViewGroup.LayoutParams params = activeMacrosRowsContainer.getLayoutParams();
+        if (params != null) { // Check if params is null, though it shouldn't be for a view in layout
+            params.height = ViewGroup.LayoutParams.WRAP_CONTENT;
+            activeMacrosRowsContainer.setLayoutParams(params);
+            activeMacrosRowsContainer.requestLayout();
+            Log.d(TAG, "displayActiveMacros: Programmatically set height to WRAP_CONTENT and requested layout.");
+        } else {
+            Log.w(TAG, "displayActiveMacros: Could not get LayoutParams for activeMacrosRowsContainer to force WRAP_CONTENT.");
         }
     }
     


### PR DESCRIPTION
This commit introduces a workaround in `MainActivity.java`'s `displayActiveMacros()` method. When macros are present and the `active_macros_rows_container` is made visible, its LayoutParams are programmatically retrieved, the height is set to `WRAP_CONTENT`, and `requestLayout()` is called.

This is an attempt to address an issue observed from logs where, in "ChatGPT Direct" mode (after `whisperSectionContainer` becomes GONE), the `active_macros_rows_container` would report its visibility as VISIBLE but its height would expand significantly (e.g., to 2042px). This resulted in a large blank space where the macros should be, with the actual buttons potentially not visible or positioned correctly within this overly large container.

This workaround tries to force a re-evaluation of the container's height based on its actual content after child views (buttons) have been added. The root cause is suspected to be related to how ConstraintLayout recalculates the layout chain when a sibling view's visibility changes.