### PR TITLE
Fix: Reduce empty space around active_prompts_display

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -238,7 +238,8 @@
         android:layout_marginTop="0dp"
         android:layout_marginBottom="0dp"
         android:gravity="center_horizontal"
-        android:padding="8dp"
+        android:paddingVertical="2dp"
+        android:paddingHorizontal="8dp"
         android:text="Active Prompts Area"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:textColor="?android:attr/textColorSecondary"
@@ -249,7 +250,7 @@
         app:layout_constraintBottom_toTopOf="@id/chatgpt_controls"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_goneMarginTop="8dp" />
+        app:layout_goneMarginTop="0dp" />
 
     <!-- The Button @+id/btn_clear_transcription was here and is now removed. -->
 


### PR DESCRIPTION
Modifies app/src/main/res/layout/content_main.xml to reduce excess vertical spacing around the `<TextView android:id="@+id/active_prompts_display" />`.

Changes:
1.  Replaced `android:padding="8dp"` with `android:paddingVertical="2dp"` and `android:paddingHorizontal="8dp"`. This reduces the top and bottom padding inside the TextView.
2.  Changed `app:layout_goneMarginTop="8dp"` to `app:layout_goneMarginTop="0dp"`. This removes the extra top margin when the `whisperSectionContainer` (to which its top is constrained) has its visibility set to GONE (e.g., in ChatGPT Direct mode).

These adjustments should make the UI tighter around the active prompts label.