### PR TITLE
Fix: Add missing transcription_failed_placeholder string resource

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,5 +194,6 @@ SpeakKey streamlines data entry, coding, writing, and any task involving text in
     <string name="main_btn_share_whisper_desc">Share Whisper text</string>
     <string name="main_btn_share_chatgpt_desc">Share ChatGPT text</string>
     <string name="main_share_chooser_title_text">Share content via</string>
+    <string name="transcription_failed_placeholder">[Transcription failed or result was empty]</string>
 
 </resources>


### PR DESCRIPTION
Adds the string resource `transcription_failed_placeholder` to app/src/main/res/values/strings.xml.

This resolves a "cannot find symbol" compilation error in MainActivity.java where `R.string.transcription_failed_placeholder` was referenced before it was defined. The MainActivity's BroadcastReceiver uses this string to display a message to you if a transcription result is null.