### PR TITLE
Refactor: Rename transcription modes

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -140,7 +140,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     protected void onCreate(Bundle savedInstanceState) {
         // Initialize settings
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
-        String transcriptionMode = sharedPreferences.getString("transcription_mode", "whisper"); // Added
+        String transcriptionMode = sharedPreferences.getString("transcription_mode", "two_step_transcription"); // Added
         
         // Apply the theme before setting content view
         ThemeManager.applyTheme(sharedPreferences);
@@ -200,7 +200,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             Log.e(TAG, "whisperSectionContainer is null in updateUiForTranscriptionMode. UI update skipped.");
             return;
         }
-        if ("chatgpt_direct".equals(mode)) {
+        if ("one_step_transcription".equals(mode)) {
             whisperSectionContainer.setVisibility(View.GONE);
             Log.d(TAG, "updateUiForTranscriptionMode: whisperSectionContainer visibility set to GONE");
             // Adjust hint for chatGptText if needed, e.g.,
@@ -214,7 +214,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                                                  .filter(Prompt::isActive)
                                                  .collect(Collectors.toList());
                 if (activePrompts.isEmpty() && activePromptsDisplay != null) {
-                    activePromptsDisplay.setText("Direct Transcription");
+                    activePromptsDisplay.setText("One Step Transcription");
                     activePromptsDisplay.setVisibility(View.VISIBLE); // Ensure it's visible
                 } else if (activePromptsDisplay != null) {
                     // If there are active prompts, updateActivePromptsDisplay will handle showing them.
@@ -696,8 +696,8 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             
             Log.d(TAG, "Recording stopped, duration: " + recordingDuration + "ms");
 
-            String transcriptionMode = sharedPreferences.getString("transcription_mode", "whisper");
-            if (transcriptionMode.equals("chatgpt_direct")) {
+            String transcriptionMode = sharedPreferences.getString("transcription_mode", "two_step_transcription");
+            if (transcriptionMode.equals("one_step_transcription")) {
 
                 String converted = convertToMp3(new File(pcmFilePath));
                 if (converted != null) {
@@ -1008,10 +1008,10 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     }
 
     private void sendToChatGpt() {
-        String transcriptionMode = sharedPreferences.getString("transcription_mode", "whisper");
+        String transcriptionMode = sharedPreferences.getString("transcription_mode", "two_step_transcription");
         Log.i(TAG, "sendToChatGpt called. Mode: " + transcriptionMode);
 
-        if (transcriptionMode.equals("chatgpt_direct")) {
+        if (transcriptionMode.equals("one_step_transcription")) {
             if (lastRecordedAudioPathForChatGPTDirect != null && new File(lastRecordedAudioPathForChatGPTDirect).exists()) {
                 Log.d(TAG, "sendToChatGpt (Direct Mode): Calling transcribeAudioWithChatGpt for MP3 file " + lastRecordedAudioPathForChatGPTDirect);
                 transcribeAudioWithChatGpt(); // This will use the MP3 and call getCompletionFromAudioAndPrompt
@@ -1192,9 +1192,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                                              .filter(Prompt::isActive)
                                              .collect(Collectors.toList());
 
-        if ("chatgpt_direct".equals(transcriptionMode)) {
+        if ("one_step_transcription".equals(transcriptionMode)) {
             if (activeSystemPrompts.isEmpty()) {
-                activePromptsDisplay.setText("Direct Transcription");
+                activePromptsDisplay.setText("One Step Transcription");
                 activePromptsDisplay.setVisibility(View.VISIBLE);
             } else {
                 // Show actual active prompts

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -37,11 +37,11 @@
     </string-array>
 
     <string-array name="transcription_mode_entries">
-        <item>Whisper</item>
-        <item>ChatGPT Direct</item>
+        <item>Two Step Transcription</item>
+        <item>One Step Transcription</item>
     </string-array>
     <string-array name="transcription_mode_values">
-        <item>whisper</item>
-        <item>chatgpt_direct</item>
+        <item>two_step_transcription</item>
+        <item>one_step_transcription</item>
     </string-array>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -32,7 +32,7 @@
             android:key="transcription_mode"
             android:title="Transcription Mode"
             android:summary="Select the transcription service to use."
-            android:defaultValue="whisper"
+            android:defaultValue="two_step_transcription"
             android:entries="@array/transcription_mode_entries"
             android:entryValues="@array/transcription_mode_values" />
 


### PR DESCRIPTION
I've renamed the transcription modes throughout the application based on your feedback for clarity.

Changes:
- "Whisper Transcription" (and internal value "whisper") is now "Two Step Transcription" (internal value "two_step_transcription").
- "ChatGPT Direct Transcription" (and internal value "chatgpt_direct") is now "One Step Transcription" (internal value "one_step_transcription").

Modifications include:
1.  `app/src/main/res/values/arrays.xml`:
    - I updated `transcription_mode_entries` for display names.
    - I updated `transcription_mode_values` for internal string values.
2.  `app/src/main/res/xml/root_preferences.xml`:
    - I updated `android:defaultValue` for the `transcription_mode` ListPreference to "two_step_transcription".
3.  `app/src/main/java/com/drgraff/speakkey/MainActivity.java`:
    - I updated the default value used when fetching `transcription_mode` from SharedPreferences.
    - I updated all conditional logic (if statements) to use the new internal string values ("one_step_transcription", "two_step_transcription").
    - I changed the display text for the active prompts area in `updateUiForTranscriptionMode` from "Direct Transcription" to "One Step Transcription".

I reviewed SettingsActivity.java and it required no changes as it dynamically loads preference data from XML.