### PR TITLE
Here's the updated commit message:

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
@@ -375,7 +375,7 @@ public class PhotosActivity extends AppCompatActivity implements FullScreenEditT
             concatenatedPromptText = getString(R.string.photos_default_image_description_prompt);
         }
 
-        String selectedPhotoModel = sharedPreferences.getString(PhotoPromptsActivity.PREF_KEY_SELECTED_PHOTO_MODEL, null);
+        String selectedPhotoModel = sharedPreferences.getString(SettingsActivity.PREF_KEY_PHOTOVISION_PROCESSING_MODEL, "gpt-4-vision-preview");
         if (selectedPhotoModel == null || selectedPhotoModel.isEmpty()) {
             Toast.makeText(this, getString(R.string.photos_toast_model_not_selected_text), Toast.LENGTH_LONG).show();
             return;

--- a/app/src/main/java/com/drgraff/speakkey/api/ChatGptApi.java
+++ b/app/src/main/java/com/drgraff/speakkey/api/ChatGptApi.java
@@ -75,7 +75,7 @@ public class ChatGptApi {
      * @return Completion from ChatGPT
      * @throws Exception if API call fails
      */
-    public String getCompletion(String prompt) throws Exception {
+    public String getCompletion(String prompt, String modelToUse) throws Exception {
         if (apiKey == null || apiKey.isEmpty()) {
             throw new IllegalArgumentException("API key is required");
         }
@@ -91,7 +91,7 @@ public class ChatGptApi {
         ChatGptApiService apiService = retrofit.create(ChatGptApiService.class);
 
         ChatGptRequest.Message userMessage = new ChatGptRequest.Message("user", prompt);
-        ChatGptRequest request = new ChatGptRequest(this.model, Collections.singletonList(userMessage));
+        ChatGptRequest request = new ChatGptRequest(modelToUse, Collections.singletonList(userMessage));
 
         String authToken = "Bearer " + this.apiKey;
 


### PR DESCRIPTION
Feature: Implement mode-specific model usage (Phase 3A)

This commit updates MainActivity, PhotosActivity, and ChatGptApi to ensure that the new mode-specific ChatGPT model preferences (defined in Settings) are correctly used for API calls.

Key changes:

1.  **MainActivity.java:**
    *   `transcribeAudioWithChatGpt()` (for "One Step Transcription" mode)
        now reads `PREF_KEY_ONESTEP_PROCESSING_MODEL` to determine the
        model for its API call.
    *   Logic for "Two Step Transcription" mode in `stopRecording()` and
        `sendToChatGpt()` (which handles Step 2 processing) updated:
        *   `stopRecording()` reads `PREF_KEY_TWOSTEP_STEP1_ENGINE`.
            *   If "whisper", uses existing UploadService flow.
            *   If "chatgpt", reads `PREF_KEY_TWOSTEP_STEP1_CHATGPT_MODEL`,
              calls `ChatGptApi.getCompletionFromAudioAndPrompt` with a
              fixed transcription prompt, and then triggers Step 2.
        *   `sendToChatGpt()` (when acting as Step 2) now reads
            `PREF_KEY_TWOSTEP_STEP2_PROCESSING_MODEL` and passes this
            model to `ChatGptApi.getCompletion`.

2.  **ChatGptApi.java:**
    *   The `getCompletion(String prompt)` method signature was changed to
        `getCompletion(String prompt, String modelToUse)` and updated
        to use the `modelToUse` parameter in its API request.

3.  **PhotosActivity.java:**
    *   `sendPhotoAndPromptsToChatGpt()` now reads the photo vision model
        from SharedPreferences using the standardized key
        `PREF_KEY_PHOTOVISION_PROCESSING_MODEL`.

This phase addresses the issue where models selected in Settings were not being correctly applied for different transcription/processing modes.