### PR TITLE
Fix: Add missing import for SettingsActivity in PhotosActivity

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
@@ -60,6 +60,7 @@ import com.drgraff.speakkey.data.UploadTask; // Added for UploadTask
 import com.drgraff.speakkey.inputstick.InputStickBroadcast; // Added
 import com.drgraff.speakkey.service.UploadService; // Added for UploadService
 import com.drgraff.speakkey.inputstick.InputStickManager;
+import com.drgraff.speakkey.settings.SettingsActivity; // Added import
 import com.drgraff.speakkey.utils.AppLogManager;
 import com.drgraff.speakkey.FullScreenEditTextDialogFragment; // Added
 


### PR DESCRIPTION
Resolves a "cannot find symbol" compilation error in PhotosActivity.java. The error occurred because PhotosActivity was trying to access the constant PREF_KEY_PHOTOVISION_PROCESSING_MODEL from SettingsActivity without importing the SettingsActivity class.

This commit adds the required import statement:
`import com.drgraff.speakkey.settings.SettingsActivity;`