### PR TITLE
Fix: Resolve OnPromptInteractionListener build error

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/data/PromptsAdapter.java
+++ b/app/src/main/java/com/drgraff/speakkey/data/PromptsAdapter.java
@@ -23,13 +23,22 @@ public class PromptsAdapter extends RecyclerView.Adapter<PromptsAdapter.PromptVi
 
     private List<Prompt> prompts;
     private final PromptManager promptManager;
-    private final Context context; // Context for starting activity
+    private final Context context;
+    private final OnPromptInteractionListener listener; // Added listener
+
+    // Interface for interaction Callbacks
+    public interface OnPromptInteractionListener {
+        void onEditPrompt(Prompt prompt);
+        // void onDeletePrompt(Prompt prompt); // Example for future
+        // void onTogglePromptActive(Prompt prompt, boolean isActive); // Example for future
+    }
 
     // Constructor updated
-    public PromptsAdapter(Context context, List<Prompt> prompts, PromptManager promptManager) {
+    public PromptsAdapter(Context context, List<Prompt> prompts, PromptManager promptManager, OnPromptInteractionListener listener) {
         this.context = context;
         this.prompts = prompts != null ? prompts : new ArrayList<>();
         this.promptManager = promptManager;
+        this.listener = listener; // Assign listener
     }
 
     @NonNull
@@ -61,9 +70,9 @@ public class PromptsAdapter extends RecyclerView.Adapter<PromptsAdapter.PromptVi
         });
 
         holder.editPromptButton.setOnClickListener(v -> {
-            Intent intent = new Intent(context, PromptEditorActivity.class);
-            intent.putExtra(PromptEditorActivity.EXTRA_PROMPT_ID, currentPrompt.getId());
-            context.startActivity(intent);
+            if (listener != null && holder.getAdapterPosition() != RecyclerView.NO_POSITION) {
+                listener.onEditPrompt(prompts.get(holder.getAdapterPosition()));
+            }
         });
 
         holder.deletePromptButton.setOnClickListener(v -> {


### PR DESCRIPTION
Corrects a build failure where PromptsActivity could not resolve OnPromptInteractionListener as a supertype.

Changes:
- In `PromptsAdapter.java`:
    - Made the inner interface `OnPromptInteractionListener` public.
    - Updated the constructor to accept an `OnPromptInteractionListener`.
    - Modified the `editPromptButton`'s OnClickListener to call `listener.onEditPrompt()` instead of starting an activity directly.

This ensures `PromptsActivity` can correctly implement the listener interface defined in `PromptsAdapter`, resolving the compilation error and correctly delegating edit actions.