### PR TITLE
fix: Resolve compilation errors for progress indicators feature

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -26,6 +26,7 @@ import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.ImageButton; // Added for ImageButton
+import android.widget.ProgressBar; // Added
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -534,10 +535,11 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                         }
                     } else { // Failure (transcriptionResult is null)
                         Log.w(TAG, "Received null transcription result for matched file path: " + receivedFilePath);
-                        String errorMessage = intent.getStringExtra(UploadService.EXTRA_ERROR_MESSAGE); // Check if service sends specific error
-                        if (errorMessage == null || errorMessage.isEmpty()) {
-                            errorMessage = getString(R.string.transcription_failed_placeholder);
-                        }
+                        // String errorMessage = intent.getStringExtra(UploadService.EXTRA_ERROR_MESSAGE); // Check if service sends specific error
+                        String errorMessage = getString(R.string.transcription_failed_placeholder); // Default to placeholder
+                        // if (errorMessage == null || errorMessage.isEmpty()) { // This check is now redundant if we always default above
+                        //     errorMessage = getString(R.string.transcription_failed_placeholder);
+                        // }
                         if (textViewWhisperStatus != null) {
                             textViewWhisperStatus.setText(errorMessage);
                             textViewWhisperStatus.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
@@ -27,6 +27,7 @@ import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.ImageButton; // Added
 import android.widget.ImageView;
+import android.widget.ProgressBar; // Added
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -705,10 +706,11 @@ public class PhotosActivity extends AppCompatActivity implements FullScreenEditT
                         }
                     } else { // Failure case (visionResult is null)
                         // Attempt to get error message from intent, if UploadService provides it
-                        String errorMessage = intent.getStringExtra(UploadService.EXTRA_ERROR_MESSAGE);
-                        if (errorMessage == null || errorMessage.isEmpty()) {
-                            errorMessage = getString(R.string.photos_vision_failed_placeholder); // Generic failure
-                        }
+                        // String errorMessage = intent.getStringExtra(UploadService.EXTRA_ERROR_MESSAGE); // Removed
+                        String errorMessage = getString(R.string.photos_vision_failed_placeholder); // Default to placeholder
+                        // if (errorMessage == null || errorMessage.isEmpty()) { // This check is now redundant
+                        //     errorMessage = getString(R.string.photos_vision_failed_placeholder); // Generic failure
+                        // }
                         Log.w(TAG, "Received null vision result or error for matched file path: " + receivedFilePath + ". Error: " + errorMessage);
 
                         textViewPhotoStatus.setText(errorMessage);


### PR DESCRIPTION
This commit addresses compilation errors encountered after the initial implementation of in-app progress indicators:

1.  **Missing ProgressBar Imports:**
    - Added `import android.widget.ProgressBar;` to `MainActivity.java` and `PhotosActivity.java` to resolve `cannot find symbol class ProgressBar` errors.

2.  **Undefined EXTRA_ERROR_MESSAGE Constant:**
    - Removed references to a non-existent `UploadService.EXTRA_ERROR_MESSAGE` constant within the broadcast receivers in `MainActivity.java` and `PhotosActivity.java`. The error handling logic now relies on checking for null results and uses placeholder strings for failure messages displayed to you, which was the intended fallback.

These changes ensure that the application compiles successfully with the new progress indicator functionality.