### PR TITLE
feat: Extend in-app progress indicators to all transcription modes

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -308,6 +308,31 @@
         <!-- btn_clear_chatgpt was removed from here -->
     </LinearLayout>
 
+    <ProgressBar
+        android:id="@+id/progressBarChatGpt"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="gone"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="4dp"
+        app:layout_constraintTop_toBottomOf="@id/chatgpt_controls"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/textViewChatGptStatus"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text=""
+        android:gravity="center_horizontal"
+        android:visibility="gone"
+        android:layout_marginBottom="4dp"
+        app:layout_constraintTop_toBottomOf="@id/progressBarChatGpt"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <!-- ChatGPT Section -->
     <TextView
         android:id="@+id/chatgpt_label"
@@ -316,7 +341,7 @@
         android:text="ChatGPT Response"
         android:layout_marginTop="2dp"
         android:textStyle="bold"
-        app:layout_constraintTop_toBottomOf="@id/chatgpt_controls"
+        app:layout_constraintTop_toBottomOf="@id/textViewChatGptStatus"
         app:layout_constraintStart_toStartOf="parent" />
 
     <LinearLayout


### PR DESCRIPTION
This commit expands the in-app progress indicators (ProgressBar and status TextView) in MainActivity to cover all transcription and processing scenarios:

1.  **One-Step Transcription (Audio to ChatGPT):**
    *   Added new UI elements (`progressBarChatGpt`, `textViewChatGptStatus`) to the ChatGPT section in `content_main.xml`.
    *   Updated `MainActivity.java` to:
        *   Initialize and manage these new UI elements.
        *   Display progress (e.g., "Processing with gpt-4o...") in the ChatGPT section when one-step transcription is initiated (both manually via "Send to ChatGPT" button in one-step mode, and via auto-send).
        *   Update this UI on success or failure.

2.  **Two-Step Transcription (ChatGPT Processing of Whisper Text):**
    *   The `sendToChatGpt()` method in `MainActivity.java` (when handling the second step of two-step transcription) now utilizes the new `progressBarChatGpt` and `textViewChatGptStatus` to display progress.
    *   This covers both manual clicks of "Send to ChatGPT" (with Whisper text) and auto-send scenarios triggered after Whisper transcription completes.

This ensures a consistent experience for you by providing visual feedback for all asynchronous AI processing tasks within `MainActivity`, complementing the earlier additions for photo processing and the Whisper part of two-step transcription.