### PR TITLE
fix: Ensure in-app progress UI renders reliably during photo auto-send

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
@@ -548,7 +548,12 @@ public class PhotosActivity extends AppCompatActivity implements FullScreenEditT
                 setPic(); // This will update currentPhotoPath and UI
                 if (chkAutoSendChatGptPhoto.isChecked() && currentPhotoPath != null && !currentPhotoPath.isEmpty()) { // Added
                     showPhotoUploadProgressUI(); // Added
-                    sendPhotoAndPromptsToChatGpt();
+                    new Handler(Looper.getMainLooper()).post(new Runnable() {
+                        @Override
+                        public void run() {
+                            sendPhotoAndPromptsToChatGpt();
+                        }
+                    });
                 }
             } else {
                 // If the user cancelled or an error occurred, delete the empty file.


### PR DESCRIPTION
This commit addresses an issue where the in-app progress indicators (ProgressBar and status TextView) in `PhotosActivity` might not display correctly during auto-send operations, especially if the main thread was busy (as indicated by "Skipped frames" in logs).

Changes:

-   In `PhotosActivity.java`, within the `onActivityResult` method's auto-send logic:
    - The call to `sendPhotoAndPromptsToChatGpt()` (which initiates the upload task) is now posted to the main thread's message queue using `new Handler(Looper.getMainLooper()).post(...)`.
    - This is done after `showPhotoUploadProgressUI()` is called.

This change ensures that the UI updates from `showPhotoUploadProgressUI()` (making the progress bar visible and setting the "Queued..." status text) are processed and have a chance to render before `sendPhotoAndPromptsToChatGpt()` is executed. This should make the "Queued..." state more reliably visible to you during auto-sends.