### PR TITLE
fix: Improve progress UI display timing for photo auto-send

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
@@ -547,10 +547,11 @@ public class PhotosActivity extends AppCompatActivity implements FullScreenEditT
             if (resultCode == RESULT_OK) {
                 setPic(); // This will update currentPhotoPath and UI
                 if (chkAutoSendChatGptPhoto.isChecked() && currentPhotoPath != null && !currentPhotoPath.isEmpty()) { // Added
-                    showPhotoUploadProgressUI(); // Added
+                    // showPhotoUploadProgressUI(); // Removed from here
                     new Handler(Looper.getMainLooper()).post(new Runnable() {
                         @Override
                         public void run() {
+                            showPhotoUploadProgressUI(); // Added here
                             sendPhotoAndPromptsToChatGpt();
                         }
                     });


### PR DESCRIPTION
This commit refines the order of operations during photo auto-send in `PhotosActivity` to improve the reliability of the initial "Queued..." progress UI display.

Previously, even with Handler.post, the UI update for "Queued..." might have been too brief or seemed to flash if the main thread was busy.

Changes:
- In `PhotosActivity.java`, within `onActivityResult`'s auto-send logic:
    - The call to `showPhotoUploadProgressUI()` (which makes the progress bar visible and sets "Queued..." text) is now moved *inside* the `Runnable` that is posted to the main thread Handler.
    - This `Runnable` now first calls `showPhotoUploadProgressUI()` and then immediately calls `sendPhotoAndPromptsToChatGpt()`.

By bundling the UI update and the subsequent action into a single posted event, this change aims to ensure that the "Queued..." status is more reliably rendered just before the task initiation logic proceeds, reducing the chances of it being missed due to main thread business or other queued UI updates.