### PR TITLE
fix: Adjust auto-send progress UI logic for photo uploads

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
@@ -560,7 +560,7 @@ public class PhotosActivity extends AppCompatActivity implements FullScreenEditT
                     new Handler(Looper.getMainLooper()).post(new Runnable() {
                         @Override
                         public void run() {
-                            showPhotoUploadProgressUI();
+                            // showPhotoUploadProgressUI(); // REMOVED
                             sendPhotoAndPromptsToChatGpt();
                         }
                     });


### PR DESCRIPTION
This commit further refines the display of in-app progress indicators during photo auto-send operations in `PhotosActivity`.

The problem of progress indicators not showing (or only flashing briefly) during auto-send persisted, likely due to heavy main thread workload during `onActivityResult` preventing UI updates from rendering, even when posted to a Handler.

Changes:
- In `PhotosActivity.java`'s `onActivityResult` method (for auto-send):
    - The `isNewPhotoTaskJustQueued` flag is set to `true` immediately.
    - The call to `showPhotoUploadProgressUI()` (which makes the progress bar visible and sets "Queued..." text) has been REMOVED from the auto-send path within `onActivityResult` (i.e., it's not called directly, nor from the Handler runnable that calls `sendPhotoAndPromptsToChatGpt`).
    - The `Handler.post()` now only queues the call to `sendPhotoAndPromptsToChatGpt()`.

- The responsibility for displaying the *initial* "Queued for processing..." UI during an auto-send now relies on the `refreshPhotoProcessingStatus()` method.
    - `refreshPhotoProcessingStatus()` (typically called by `onResume` shortly after `onActivityResult`) will detect that `isNewPhotoTaskJustQueued` is true.
    - If it doesn't yet find the newly created task in the database (because the background DB insert from `sendPhotoAndPromptsToChatGpt` hasn't completed), it will now be responsible for setting the "Queued for processing..." text, making the progress bar visible, and disabling the send button.
    - The existing logic in `refreshPhotoProcessingStatus` to handle this case (when flag is true and no active task is found) was verified to be correct.

This approach delays the initial UI update for progress until `refreshPhotoProcessingStatus` runs (likely via `onResume`), which should occur when the main thread is less contended after `onActivityResult` has finished its immediate processing. This is expected to make the "Queued..." state more reliably visible during auto-sends.