### PR TITLE
fix: Attempt synchronous UI update for photo auto-send progress

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
@@ -557,10 +557,10 @@ public class PhotosActivity extends AppCompatActivity implements FullScreenEditT
                 setPic(); // This will update currentPhotoPath and UI
                 if (chkAutoSendChatGptPhoto.isChecked() && currentPhotoPath != null && !currentPhotoPath.isEmpty()) { // Added
                     isNewPhotoTaskJustQueued = true; // Set flag immediately
+                    showPhotoUploadProgressUI();    // Attempt synchronous UI update
                     new Handler(Looper.getMainLooper()).post(new Runnable() {
                         @Override
                         public void run() {
-                            // showPhotoUploadProgressUI(); // REMOVED
                             sendPhotoAndPromptsToChatGpt();
                         }
                     });


### PR DESCRIPTION
This commit further refines the logic in `PhotosActivity.onActivityResult` for displaying in-app progress indicators during auto-send operations, aiming to make the initial "Queued..." state more reliably visible.

Problem Recap:
Even with previous Handler.post strategems, "Skipped frames" during `onActivityResult` sometimes prevented the progress UI from rendering effectively before the task completed.

Changes:
- In `PhotosActivity.java`, within `onActivityResult`'s auto-send `if` block:
    1. `isNewPhotoTaskJustQueued = true;` is set immediately (as per the previous fix, this remains crucial).
    2. `showPhotoUploadProgressUI();` is now called *directly* and *synchronously* after setting the flag. This attempts an immediate update of the UI to show the "Queued for processing..." state.
    3. The call to `sendPhotoAndPromptsToChatGpt()` (which initiates the actual upload task) remains posted to the main thread's Handler to run after `onActivityResult` completes its current execution block.

Rationale:
- The direct call to `showPhotoUploadProgressUI()` attempts to get the progress state onto the screen as quickly as possible.
- The `isNewPhotoTaskJustQueued` flag, combined with the robust logic in `refreshPhotoProcessingStatus()`, acts as a safeguard: if `onResume` triggers a refresh before the new task is fully in the database, `refreshPhotoProcessingStatus` will see the flag and ensure the "Queued..." UI state is maintained or re-established.

This provides two main opportunities for the "Queued..." UI to be set correctly: once synchronously, and again via `refreshPhotoProcessingStatus` if needed, aiming to overcome main thread contention during `onActivityResult`.