### PR TITLE
Hi, I've made a change to improve the visibility of the photo auto-se…

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
@@ -557,11 +557,22 @@ public class PhotosActivity extends AppCompatActivity implements FullScreenEditT
                 setPic(); // This will update currentPhotoPath and UI
                 if (chkAutoSendChatGptPhoto.isChecked() && currentPhotoPath != null && !currentPhotoPath.isEmpty()) { // Added
                     isNewPhotoTaskJustQueued = true; // Set flag immediately
-                    showPhotoUploadProgressUI();    // Attempt synchronous UI update
-                    new Handler(Looper.getMainLooper()).post(new Runnable() {
+                    // Removed direct call to showPhotoUploadProgressUI() here. It's now in the first post.
+                    mainHandler.post(new Runnable() { // Post the UI update
                         @Override
                         public void run() {
-                            sendPhotoAndPromptsToChatGpt();
+                            showPhotoUploadProgressUI();
+                            // After showing UI, post the next action with a delay
+                            mainHandler.postDelayed(new Runnable() {
+                                @Override
+                                public void run() {
+                                    // Check if the activity is still in a valid state to proceed,
+                                    // as a delay has occurred. This is an optional guard.
+                                    if (!isFinishing() && !isDestroyed()) {
+                                         sendPhotoAndPromptsToChatGpt();
+                                    }
+                                }
+                            }, 100); // 100 millisecond delay
                         }
                     });
                 }


### PR DESCRIPTION
…nd progress UI.

This change refines how in-app progress indicators are displayed during photo auto-send in `PhotosActivity`. I've introduced a small delay between showing the progress UI and starting the upload. This should help ensure the UI updates appear even if things are busy when `onActivityResult` is called.

Here's what I did:
- In `PhotosActivity.java`, within `onActivityResult`'s auto-send `if` block:
    1. I set `isNewPhotoTaskJustQueued = true;` immediately.
    2. I scheduled a piece of work for the `mainHandler`. This work will: a. Call `showPhotoUploadProgressUI()` to display the "Queued..." state. b. Then, schedule *another* piece of work for the `mainHandler` with a 100ms delay. This second piece of work contains the call to `sendPhotoAndPromptsToChatGpt()`.

The idea behind the 100ms delay after trying to show the "Queued..." UI is to give the Android UI system a moment to process and show these changes before the next operations (starting the upload) begin. This should help with situations where the initial progress state wasn't visible to you during auto-send. The `isNewPhotoTaskJustQueued` flag continues to ensure `refreshPhotoProcessingStatus` works reliably.