### PR TITLE
Fix: Show progress indicator for photo auto-send

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
@@ -576,9 +576,9 @@ public class PhotosActivity extends AppCompatActivity implements FullScreenEditT
             if (resultCode == RESULT_OK) {
                 setPic(); // This will update currentPhotoPath and UI
                 if (chkAutoSendChatGptPhoto.isChecked() && currentPhotoPath != null && !currentPhotoPath.isEmpty()) {
-                    isNewPhotoTaskJustQueued = true; // Set flag immediately
-                    // Post only the sendPhotoAndPromptsToChatGpt call to the handler.
-                    // NO call to showPhotoUploadProgressUI() should be in this onActivityResult block for auto-send.
+                    // Call showPhotoUploadProgressUI() before posting to the handler
+                    showPhotoUploadProgressUI();
+                    // The isNewPhotoTaskJustQueued = true flag is set inside showPhotoUploadProgressUI(), so no need to set it here explicitly.
                     new Handler(Looper.getMainLooper()).post(new Runnable() {
                         @Override
                         public void run() {


### PR DESCRIPTION
The auto-send functionality in PhotosActivity was not displaying the progress bar or status messages because it directly called the sendPhotoAndPromptsToChatGpt() method without first invoking showPhotoUploadProgressUI().

This commit fixes the issue by adding a call to showPhotoUploadProgressUI() in the onActivityResult method when a photo is taken and auto-send is enabled. This ensures that the UI updates to show progress immediately, consistent with the manual send functionality.