### PR TITLE
Fix: Standardize prompt creation and ensure correct field assignment

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/data/PromptManager.java
+++ b/app/src/main/java/com/drgraff/speakkey/data/PromptManager.java
@@ -129,17 +129,17 @@ public class PromptManager {
         sharedPreferences.edit().putString(PROMPTS_KEY, json).apply();
     }
 
-    public void addPrompt(String text, String label, String promptModeType) {
+    // Signature changed: label first, then text
+    public void addPrompt(String label, String text, String promptModeType) {
         List<Prompt> prompts = getAllPrompts();
         long newId = System.currentTimeMillis(); // Simple unique ID
         // Add timestamp to the Prompt constructor call
-        // Swapped 'text' and 'label' parameters in the Prompt constructor call
-        // to correctly map from PhotoPromptEditorActivity's call:
-        // addPrompt(labelFromUi, textFromUi, mode)
-        // where addPrompt's 'text' param receives uiLabel and 'label' param receives uiText.
-        // Prompt constructor wants (..., promptText, ..., promptLabel, ...),
-        // so we pass addPrompt's 'label' param for promptText, and 'text' param for promptLabel.
-        prompts.add(new Prompt(newId, label, false, text, promptModeType, newId));
+        // Parameters to Prompt constructor now directly match the new method signature:
+        // Prompt(id, textValue, isActive, labelValue, mode, order)
+        // New addPrompt signature is (label, text, mode), so:
+        // textValue for Prompt is 'text' (2nd param of addPrompt)
+        // labelValue for Prompt is 'label' (1st param of addPrompt)
+        prompts.add(new Prompt(newId, text, false, label, promptModeType, newId));
         savePrompts(prompts);
     }
 

--- a/app/src/main/java/com/drgraff/speakkey/data/PromptsActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/data/PromptsActivity.java
@@ -445,7 +445,8 @@ public class PromptsActivity extends AppCompatActivity implements PromptsAdapter
                 }
 
                 if (promptManager != null) {
-                    promptManager.addPrompt(originalText, newLabel, destinationModeType);
+                    // Updated to match new signature: addPrompt(label, text, mode)
+                    promptManager.addPrompt(newLabel, originalText, destinationModeType);
                     Toast.makeText(PromptsActivity.this, getString(R.string.prompt_copied_toast_format, spinnerDestinationMode.getSelectedItem().toString()), Toast.LENGTH_SHORT).show();
                     loadAllPromptsSections();
                 } else {


### PR DESCRIPTION
This commit addresses the issue of swapped Label and Text fields when creating or copying Photo Prompts by standardizing the `PromptManager.addPrompt` method and updating its callers.

1.  **PromptManager.addPrompt Signature Change:** The method signature has been changed from `addPrompt(String text, String label, String promptModeType)` to a more semantically clear `addPrompt(String label, String text, String promptModeType)`.

2.  **PromptManager.addPrompt Internal Logic:** The creation of the `Prompt` object within `addPrompt` now correctly uses the `label` and `text` parameters from the new signature: `new Prompt(newId, text, false, label, promptModeType, newId)` ensuring `Prompt.text` gets the `text` content and `Prompt.label` gets the `label` content.

3.  **Updated Call Site in PromptsActivity.onCopyPrompt:** The call to `addPrompt` within the copy functionality in `PromptsActivity` has been updated from `promptManager.addPrompt(originalText, newLabel, destinationModeType)` to `promptManager.addPrompt(newLabel, originalText, destinationModeType)` to align with the new signature, ensuring the new label is treated as the label and the original text as the text.

4.  **Call Site in PhotoPromptEditorActivity:** The call `promptManager.addPrompt(label, text, "photo_vision")` in `PhotoPromptEditorActivity` already matched the new standardized signature and required no change.

These changes should ensure that prompt labels and text content are consistently and correctly handled during creation and copying.