### PR TITLE
Fix: Correct swapped Label/Text for new one-step/two-step prompts

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/ui/prompts/PromptEditorActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/ui/prompts/PromptEditorActivity.java
@@ -119,7 +119,8 @@ public class PromptEditorActivity extends AppCompatActivity {
                 modeTypeForNewPrompt = "two_step_processing"; // Fallback default
                 android.util.Log.w("PromptEditorActivity", "PROMPT_MODE_TYPE extra not found, defaulting to " + modeTypeForNewPrompt);
             }
-            promptManager.addPrompt(text, label, modeTypeForNewPrompt); // isActive is false by default in addPrompt
+        // Corrected order for addPrompt(label, text, mode)
+        promptManager.addPrompt(label, text, modeTypeForNewPrompt);
             Toast.makeText(this, R.string.prompt_saved_message, Toast.LENGTH_SHORT).show();
         }
         setResult(Activity.RESULT_OK);


### PR DESCRIPTION
This commit fixes an issue in `PromptEditorActivity.java` where new prompts for one-step and two-step dictation modes had their label and text fields swapped upon saving.

The `PromptManager.addPrompt` method was previously standardized to the signature `addPrompt(String label, String text, String promptModeType)`. However, `PromptEditorActivity.savePrompt()` was still calling it with the arguments in the old order: `promptManager.addPrompt(text, label, type)`.

This commit updates the call in `PromptEditorActivity.savePrompt()` to:
  `promptManager.addPrompt(label, text, modeTypeForNewPrompt)`
where `label` is the content from the UI label field and `text` is the content from the UI text field.

This ensures that the label and text are passed in the correct order to `PromptManager.addPrompt`, resolving the field swap for these prompt modes.