### PR TITLE
Feat: Display default prompt text in Two-Step mode

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -1410,8 +1410,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             }
         } else { // "two_step_transcription" mode
             if (activeSystemPrompts.isEmpty()) {
-                activePromptsDisplay.setText(""); // Or "No active prompts for two-step"
-                activePromptsDisplay.setVisibility(View.GONE); // Hide if no prompts for this mode
+                // Get the default text from a string resource
+                activePromptsDisplay.setText(getString(R.string.default_two_step_prompt_label));
+                activePromptsDisplay.setVisibility(View.VISIBLE); // Ensure it's visible
             } else {
                 // Show active "two_step_processing" prompts
                 String promptsText = activeSystemPrompts.stream()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="save_edit">Save</string> <!-- String for Save button in full-screen edit dialog -->
     <string name="clear_all_button_text">Clear All</string>
     <string name="clear_all_content_description">Clear all text fields</string>
+    <string name="default_two_step_prompt_label">Transcription only: Click to activate prompt</string>
     
     <!-- Settings -->
     <string name="title_activity_settings">Settings</string>


### PR DESCRIPTION
This commit enhances the MainActivity's Two-Step transcription mode. When no specific prompt is active for Two-Step mode, it now displays a default text: "Transcription only: Click to activate prompt".

Changes:
- Modified `MainActivity.updateActivePromptsDisplay()` to set this default text on the `activePromptsDisplay` TextView and ensure its visibility when no two-step prompts are active.
- Added a new string resource `default_two_step_prompt_label` in `strings.xml` for this message.
- The existing click listener on `activePromptsDisplay` will allow you to click this default text to navigate to the prompts screen, filtered for two-step prompts.

This provides better feedback to you and improves consistency with how the One-Step mode indicates its default state.