### PR TITLE
Fix: Correct addPrompt call in PhotoPromptEditorActivity

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/ui/prompts/PhotoPromptEditorActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/ui/prompts/PhotoPromptEditorActivity.java
@@ -106,7 +106,8 @@ public class PhotoPromptEditorActivity extends AppCompatActivity {
             promptManager.updatePrompt(currentPrompt); // Changed
             Toast.makeText(this, getString(R.string.photo_prompt_editor_toast_updated), Toast.LENGTH_SHORT).show();
         } else {
-            promptManager.addPrompt(label, text, "photo_vision"); // Changed
+            // Added empty string for transcriptionHint as it's not used by photo prompts.
+            promptManager.addPrompt(label, text, "", "photo_vision");
             Toast.makeText(this, getString(R.string.photo_prompt_editor_toast_added), Toast.LENGTH_SHORT).show();
         }
 


### PR DESCRIPTION
This commit fixes a build error caused by an incorrect method call signature in `PhotoPromptEditorActivity.java`.

The `PromptManager.addPrompt` method signature was previously updated to include a `transcriptionHint` parameter:
`addPrompt(String label, String text, String transcriptionHint, String promptModeType)`

The call to this method in `PhotoPromptEditorActivity.savePhotoPrompt()` (for creating new photo prompts) was not updated to provide this fourth argument. Photo prompts do not use transcription hints.

This commit updates the call to:
  `promptManager.addPrompt(label, text, "", "photo_vision");`
passing an empty string for the `transcriptionHint`.

This resolves the compilation error "actual and formal argument lists differ in length".