### PR TITLE
Refactor: Route all Step 1 transcriptions via UploadService for consi…

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/service/UploadService.java
+++ b/app/src/main/java/com/drgraff/speakkey/service/UploadService.java
@@ -351,14 +351,26 @@ public class UploadService extends IntentService {
             return false;
         }
 
-        WhisperApi whisperApi = new WhisperApi(apiKey, whisperEndpoint, language);
+        // WhisperApi whisperApi = new WhisperApi(apiKey, whisperEndpoint, language); // Old direct WhisperApi call
+        ChatGptApi chatGptApi = new ChatGptApi(apiKey, ""); // Initialize ChatGptApi; model param not directly used by getTranscriptionFromAudio
+
+        String modelToUse = (task.modelNameForTranscription != null && !task.modelNameForTranscription.isEmpty())
+                            ? task.modelNameForTranscription
+                            : "whisper-1"; // Fallback if somehow still null/empty
+        String hintToUse = (task.transcriptionHint != null)
+                            ? task.transcriptionHint
+                            : ""; // Fallback if somehow null
+
+        Log.d(TAG, "UploadService: Transcribing audio task ID: " + task.id +
+                   " with model: " + modelToUse + " and hint: '" + hintToUse + "'");
 
         try {
             Log.d(TAG, "Task ID: " + task.id + " - Setting status to PROCESSING before API call (audio).");
             task.status = UploadTask.STATUS_PROCESSING;
             uploadTaskDao.update(task);
 
-            String transcriptionResultText = whisperApi.transcribe(audioFile);
+            // final String transcription = chatGptApi.getTranscriptionFromAudio(audioFile, hintToUse, modelToUse);
+            String transcriptionResultText = chatGptApi.getTranscriptionFromAudio(audioFile, hintToUse, modelToUse); // Corrected variable name
             task.transcriptionResult = transcriptionResultText;
             Log.d(TAG, "Actual audio transcription successful for task ID: " + task.id + ". Result length: " + (transcriptionResultText != null ? transcriptionResultText.length() : "null"));
             return true;


### PR DESCRIPTION
…stent UI

This commit refactors the Step 1 transcription process in Two-Step mode to ensure consistent progress indication and robust background handling by routing all paths through the `UploadService`.

Previously, the "OpenAI Transcription Model" (user-selected via settings, e.g., 'whisper-1' with custom hints) made a direct API call from MainActivity, while the default "Whisper" engine used UploadService. This led to inconsistent progress UI.

Changes:

1.  **`UploadTask.java`:**
    - Added `modelNameForTranscription` (String) and `transcriptionHint` (String) fields to store parameters for transcription API calls.
    - Updated constructors to initialize these fields. The constructor used by the default Whisper path now defaults these to "whisper-1" and an empty hint, respectively.

2.  **`UploadService.java`:**
    - Modified to retrieve `modelNameForTranscription` and `transcriptionHint` from the `UploadTask`.
    - It now uses `chatGptApi.getTranscriptionFromAudio()` with these task-specific parameters, allowing for user-selected models and hints to be processed via the service.
    - If `modelNameForTranscription` is not set in the task, it defaults to "whisper-1" and an empty hint.

3.  **`MainActivity.java`:**
    -   `transcribeAudio()` (for default Whisper Step 1): Verified that the
        `UploadTask` created here correctly utilizes constructor defaults
        for model name ("whisper-1") and hint ("").
    -   `stopRecording()` (for "OpenAI Transcription Model" Step 1):
        -   Removed the direct threaded call to `chatGptApi.getTranscriptionFromAudio()`.
        -   Now creates an `UploadTask` populated with the `audioFilePath`,
            `TYPE_AUDIO_TRANSCRIPTION`, your selected transcription model
            (from settings, e.g., "whisper-1"), and the `transcriptionHint`
            (from the active two-step prompt).
        -   This task is then saved to the database, and `UploadService` is started.
        -   `showAudioTranscriptionProgressUI()` is called to provide immediate
            "queued" feedback, consistent with the default Whisper path.

This refactoring ensures all Step 1 audio transcriptions are handled by `UploadService`, providing a unified mechanism for background processing, error handling, and UI updates (via `TranscriptionBroadcastReceiver` and `refreshTranscriptionStatus`), leading to a consistent experience for you for progress indication regardless of the chosen Step 1 engine.