### PR TITLE
Refactor: Use Static Factory Methods for UploadTask Creation

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -769,10 +769,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                         audioFilePath = convertedFilePath; // Keep this to ensure broadcast receiver can match
                         // lastRecordedAudioPathForChatGPTDirect = convertedFilePath; // This might not be needed anymore
 
-                        // Create UploadTask with the specific model and hint
-                        UploadTask uploadTask = new UploadTask(
+                        // Create UploadTask with the specific model and hint using factory method
+                        UploadTask uploadTask = UploadTask.createAudioTranscriptionTask(
                             audioFilePath,
-                            UploadTask.TYPE_AUDIO_TRANSCRIPTION,
                             step1ModelName, // modelNameForTranscription
                             transcriptionHint // transcriptionHint
                         );
@@ -917,9 +916,8 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         Toast.makeText(this, "Queueing transcription...", Toast.LENGTH_SHORT).show(); // Changed message
         AppLogManager.getInstance().addEntry("INFO", "Whisper: Queuing transcription task...", null);
 
-        // Create UploadTask
-        UploadTask uploadTask = new UploadTask(audioFilePath, UploadTask.TYPE_AUDIO_TRANSCRIPTION);
-        // All other fields (status, retryCount, creationTimestamp) are set in the constructor
+        // Create UploadTask using factory method for default Whisper path
+        UploadTask uploadTask = UploadTask.createAudioTranscriptionTask(audioFilePath, "whisper-1", "");
 
         // Get DAO and insert in background
         AppDatabase database = AppDatabase.getDatabase(getApplicationContext());

--- a/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
@@ -480,11 +480,10 @@ public class PhotosActivity extends AppCompatActivity implements FullScreenEditT
         // UI update logic moved to showPhotoUploadProgressUI() and called by callers.
         AppLogManager.getInstance().addEntry("INFO", TAG + ": Queuing photo processing task.", "File: " + currentPhotoPath);
 
-        UploadTask uploadTask = new UploadTask(
+        UploadTask uploadTask = UploadTask.createPhotoVisionTask(
                 currentPhotoPath,
-                UploadTask.TYPE_PHOTO_VISION,
-                concatenatedPromptText, // Storing the full prompt text
-                selectedPhotoModel      // Storing the model name
+                concatenatedPromptText, // This is the visionPrompt
+                selectedPhotoModel      // This is the visionModelName
         );
 
         AppDatabase database = AppDatabase.getDatabase(getApplicationContext());

--- a/app/src/main/java/com/drgraff/speakkey/data/UploadTask.java
+++ b/app/src/main/java/com/drgraff/speakkey/data/UploadTask.java
@@ -28,7 +28,7 @@ public class UploadTask {
 
     // Fields for PHOTO_VISION
     public String promptText;
-    public String modelName;  // This is for the vision model
+    public String modelName;  // This is for the vision model used in PHOTO_VISION tasks
     public String visionApiResponse;
 
     // Status constants
@@ -42,51 +42,43 @@ public class UploadTask {
     public static final String TYPE_AUDIO_TRANSCRIPTION = "AUDIO_TRANSCRIPTION";
     public static final String TYPE_PHOTO_VISION = "PHOTO_VISION";
 
-    // No-arg constructor for Room
+    // No-arg constructor for Room and factory methods
     public UploadTask() {
         this.status = STATUS_PENDING;
         this.retryCount = 0;
         this.creationTimestamp = System.currentTimeMillis();
+        // Ensure all fields have a default state if not set by factory
+        this.filePath = null;
+        this.uploadType = null;
+        this.lastAttemptTimestamp = 0;
+        this.errorMessage = null;
+        this.transcriptionResult = null;
+        this.modelNameForTranscription = null;
+        this.transcriptionHint = null;
+        this.promptText = null;
+        this.modelName = null;
+        this.visionApiResponse = null;
     }
 
-    // General purpose constructor for manual instantiation, especially for older audio tasks or basic setup
-    // This will be called by old code that only knows about filePath and uploadType for audio.
-    // New audio tasks should use the more specific constructor.
-    @Ignore
-    public UploadTask(String filePath, String uploadType) {
-        this(); // Calls no-arg constructor for defaults
-        this.filePath = filePath;
-        this.uploadType = uploadType;
-        // Default transcription model and hint if not specified (e.g. for older Whisper via UploadService path)
-        if (TYPE_AUDIO_TRANSCRIPTION.equals(uploadType)) {
-            this.modelNameForTranscription = "whisper-1"; // Default model
-            this.transcriptionHint = ""; // Default empty hint
-        }
+    // Factory method for Photo Vision Tasks
+    public static UploadTask createPhotoVisionTask(String filePath, String visionPrompt, String visionModelName) {
+        UploadTask task = new UploadTask();
+        task.filePath = filePath;
+        task.uploadType = TYPE_PHOTO_VISION;
+        task.promptText = visionPrompt;
+        task.modelName = visionModelName; // This is for the vision model
+        // other fields (like transcription ones) remain default null/empty
+        return task;
     }
 
-    // Constructor specifically for new Audio Transcription tasks including model and hint
-    @Ignore
-    public UploadTask(String filePath, String uploadType, String modelNameForTranscription, String transcriptionHint) {
-        this(); // Calls no-arg constructor for defaults
-        if (!TYPE_AUDIO_TRANSCRIPTION.equals(uploadType)) {
-            throw new IllegalArgumentException("This constructor is for AUDIO_TRANSCRIPTION tasks. Type was: " + uploadType);
-        }
-        this.filePath = filePath;
-        this.uploadType = uploadType;
-        this.modelNameForTranscription = modelNameForTranscription;
-        this.transcriptionHint = transcriptionHint;
-    }
-
-    // Constructor for Photo Vision tasks
-    @Ignore
-    public UploadTask(String filePath, String uploadType, String visionPrompt, String visionModel) {
-        this(); // Calls no-arg constructor for defaults
-        if (!TYPE_PHOTO_VISION.equals(uploadType)) {
-            throw new IllegalArgumentException("This constructor is for PHOTO_VISION tasks. Type was: " + uploadType);
-        }
-        this.filePath = filePath;
-        this.uploadType = uploadType;
-        this.promptText = visionPrompt;
-        this.modelName = visionModel; // This is for the vision model name
+    // Factory method for Audio Transcription Tasks
+    public static UploadTask createAudioTranscriptionTask(String filePath, String modelName, String hint) {
+        UploadTask task = new UploadTask();
+        task.filePath = filePath;
+        task.uploadType = TYPE_AUDIO_TRANSCRIPTION;
+        task.modelNameForTranscription = (modelName != null && !modelName.isEmpty()) ? modelName : "whisper-1";
+        task.transcriptionHint = hint != null ? hint : "";
+        // other fields (like photo vision ones) remain default null/empty
+        return task;
     }
 }


### PR DESCRIPTION
This commit refactors `UploadTask.java` to resolve a build error caused by duplicate constructor signatures and to improve the clarity and robustness of task instantiation.

Problem:
- Adding a new constructor for audio transcription tasks with specific model and hint parameters (`String, String, String, String`) clashed with the existing constructor for photo vision tasks which had the same signature.

Solution:
1.  **`UploadTask.java` Changes:**
    - Removed the problematic public specialized constructors (2-arg and 4-arg).
    - Ensured a public no-arg constructor initializes all fields to sensible defaults (for Room and internal factory use).
    - Added `public static UploadTask createPhotoVisionTask(String filePath, String visionPrompt, String visionModelName)`: This factory method now handles the creation and configuration of photo vision tasks, setting `uploadType` to `TYPE_PHOTO_VISION`.
    - Added `public static UploadTask createAudioTranscriptionTask(String filePath, String modelName, String hint)`: This factory method handles creation of audio transcription tasks, setting `uploadType` to `TYPE_AUDIO_TRANSCRIPTION`. It populates `modelNameForTranscription` (defaulting to "whisper-1" if `modelName` is null/empty) and `transcriptionHint` (defaulting to "" if `hint` is null).

2.  **Updated Call Sites:**
    -   **`PhotosActivity.java`**: In `sendPhotoAndPromptsToChatGpt()`,
        the instantiation of `UploadTask` now uses
        `UploadTask.createPhotoVisionTask()`.
    -   **`MainActivity.java`**:
        -   In `transcribeAudio()` (default Whisper path for Step 1),
            `UploadTask` creation now uses
            `UploadTask.createAudioTranscriptionTask(audioFilePath, "whisper-1", "")`.
        -   In `stopRecording()` (for the "OpenAI Transcription Model" path
            for Step 1), `UploadTask` creation now uses
            `UploadTask.createAudioTranscriptionTask(audioFilePath, step1ModelName, transcriptionHint)`.

This refactoring resolves the build error and makes the creation of different `UploadTask` types more explicit and less error-prone. It also correctly supports the ongoing work for transcription hints and consistent Step 1 transcription processing via `UploadService`.