### PR TITLE
Fix: Implement Room DB migration for UploadTask schema changes

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/data/AppDatabase.java
+++ b/app/src/main/java/com/drgraff/speakkey/data/AppDatabase.java
@@ -2,16 +2,30 @@ package com.drgraff.speakkey.data;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
 import androidx.room.Database;
 import androidx.room.Room;
 import androidx.room.RoomDatabase;
+import androidx.room.migration.Migration;
+import androidx.sqlite.db.SupportSQLiteDatabase;
 
-@Database(entities = {UploadTask.class}, version = 1, exportSchema = false) // Set exportSchema to true if you plan to export schemas
+@Database(entities = {UploadTask.class}, version = 2, exportSchema = false) // Incremented version
 public abstract class AppDatabase extends RoomDatabase {
 
     public abstract UploadTaskDao uploadTaskDao();
 
     private static volatile AppDatabase INSTANCE;
+
+    // Migration from version 1 to 2
+    static final Migration MIGRATION_1_2 = new Migration(1, 2) {
+        @Override
+        public void migrate(@NonNull SupportSQLiteDatabase database) {
+            // Add new columns for UploadTask table.
+            // The table name is "upload_tasks" as defined in UploadTask.java @Entity annotation
+            database.execSQL("ALTER TABLE upload_tasks ADD COLUMN model_name_for_transcription TEXT");
+            database.execSQL("ALTER TABLE upload_tasks ADD COLUMN transcription_hint TEXT");
+        }
+    };
 
     public static AppDatabase getDatabase(final Context context) {
         if (INSTANCE == null) {
@@ -19,9 +33,8 @@ public abstract class AppDatabase extends RoomDatabase {
                 if (INSTANCE == null) {
                     INSTANCE = Room.databaseBuilder(context.getApplicationContext(),
                             AppDatabase.class, "speakkey_database")
-                            // Consider adding migration strategies for production apps
-                            // .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
-                            .fallbackToDestructiveMigration() // Use this only during development
+                            .addMigrations(MIGRATION_1_2) // Added migration
+                            // .fallbackToDestructiveMigration() // Removed
                             .build();
                 }
             }


### PR DESCRIPTION
This commit resolves a runtime crash (`java.lang.IllegalStateException`) that occurred after adding new fields (`modelNameForTranscription` and `transcriptionHint`) to the `UploadTask` entity. The crash was due to a schema mismatch without a corresponding database version update and migration strategy.

Changes in `AppDatabase.java`:
1.  The database version in the `@Database` annotation has been incremented from 1 to 2.
2.  A static `Migration` object (`MIGRATION_1_2`) has been defined to handle the schema upgrade from version 1 to 2. This migration adds the new columns `model_name_for_transcription` (TEXT) and `transcription_hint` (TEXT) to the `upload_tasks` table using `ALTER TABLE` SQL commands.
3.  The Room database builder in `getDatabase()` has been updated to use `.addMigrations(MIGRATION_1_2)` and `.fallbackToDestructiveMigration()` has been removed.

This ensures that the database schema is correctly updated for existing installations, preventing the app from crashing on launch due to schema verification errors.