### PR TITLE
Fix: Declare missing editTextBackgroundColorCustom theme attribute

### DIFF
--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <attr name="editTextBackgroundColorCustom" format="color" />
+</resources>


### PR DESCRIPTION
This commit fixes a build failure that occurred during resource processing ("error: style attribute 'attr/editTextBackgroundColorCustom' not found"). The attribute was used in `AppTheme.OLED` within `themes.xml` but was not declared.

This commit adds a new file `app/src/main/res/values/attrs.xml` with the following content:

```xml
<?xml version="1.0" encoding="utf-8"?>
<resources>
    <attr name="editTextBackgroundColorCustom" format="color" />
</resources>
```

This declaration makes the custom attribute available to the resource linker, resolving the build error.