### PR TITLE
Fix: Handle ClassCastException in ThemeManager for dark_mode preference

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/utils/ThemeManager.java
+++ b/app/src/main/java/com/drgraff/speakkey/utils/ThemeManager.java
@@ -1,6 +1,7 @@
 package com.drgraff.speakkey.utils;
 
 import android.content.SharedPreferences;
+import android.util.Log; // For logging migration
 import androidx.appcompat.app.AppCompatDelegate;
 
 /**
@@ -10,33 +11,55 @@ public class ThemeManager {
     
     // Key for the theme selection preference
     public static final String PREF_KEY_DARK_MODE = "dark_mode";
-    // Default value if the preference is not set
-    public static final String THEME_DEFAULT = "default";
+
+    // Theme values
+    public static final String THEME_LIGHT = "light";
+    public static final String THEME_DARK = "dark";
+    public static final String THEME_OLED = "oled";
+    public static final String THEME_DEFAULT = "default"; // System default
 
     /**
-     * Apply the appropriate theme based on the theme preference
+     * Apply the appropriate theme based on the theme preference.
+     * Handles migration from an old boolean preference to the new string-based preference.
      * 
      * @param sharedPreferences SharedPreferences instance containing theme settings
      */
     public static void applyTheme(SharedPreferences sharedPreferences) {
-        // Read the theme preference. Fallback to "default" (system default).
-        String themeValue = sharedPreferences.getString(PREF_KEY_DARK_MODE, THEME_DEFAULT);
+        String themeValue;
+        try {
+            // Try to get it as a String first (new format)
+            themeValue = sharedPreferences.getString(PREF_KEY_DARK_MODE, THEME_DEFAULT);
+        } catch (ClassCastException e) {
+            // If ClassCastException, it's an old boolean preference
+            Log.w("ThemeManager", "Old boolean 'dark_mode' preference found. Migrating to string.");
+            boolean oldDarkMode = sharedPreferences.getBoolean(PREF_KEY_DARK_MODE, false); // false was default for SwitchPreference
+
+            if (oldDarkMode) {
+                themeValue = THEME_DARK;
+            } else {
+                themeValue = THEME_LIGHT;
+                // Mapping old 'false' (which meant light theme) to the new explicit "light".
+                // If it should map to system default, THEME_DEFAULT would be used here.
+            }
+            // Save the migrated value back as a string
+            sharedPreferences.edit().putString(PREF_KEY_DARK_MODE, themeValue).apply();
+        }
         
         switch (themeValue) {
-            case "light":
+            case THEME_LIGHT:
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
                 break;
-            case "dark":
+            case THEME_DARK:
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
                 // Assumes AppTheme.Dark or base dark theme is applied by the system
                 break;
-            case "oled":
+            case THEME_OLED:
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
                 // Assumes R.style.AppTheme_OLED is correctly parented from a DayNight theme
                 // and will be picked up when MODE_NIGHT_YES is active.
                 break;
-            case "default":
-            default: // Handles "default" or any unexpected values
+            case THEME_DEFAULT:
+            default: // Handles "default" or any unexpected/new values gracefully by falling to system
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);
                 break;
         }


### PR DESCRIPTION
This commit fixes a runtime crash (ClassCastException) that occurred when `ThemeManager.applyTheme()` tried to read the "dark_mode" preference as a String, while it was still stored as a Boolean for users with previous app versions. This happened after the theme preference was changed from a SwitchPreference (Boolean) to a ListPreference (String) to support multiple themes (Light, Dark, OLED).

Changes in `ThemeManager.java`:
- The `applyTheme` method now includes a try-catch block when reading the `PREF_KEY_DARK_MODE` ("dark_mode") preference.
- If a `ClassCastException` is caught:
    - The old boolean value is read.
    - It's converted to the new string equivalent: `true` becomes "dark", `false` becomes "light".
    - This new string value is saved back to SharedPreferences, effectively migrating your preference.
- The method then proceeds to use the (now string) theme value to set the appropriate `AppCompatDelegate.setDefaultNightMode()`.
- Added public static final String constants for theme values for clarity.

This ensures backward compatibility for the theme preference and prevents the app from crashing for users updating from an older version.