### PR TITLE
Fix: Correct ListPreference definition for theme selection

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -54,4 +54,19 @@
         <item>whisper</item> <!-- Internal value for choosing Whisper -->
         <item>chatgpt</item> <!-- Internal value for choosing ChatGPT for transcription step -->
     </string-array>
+
+    <!-- Dark Mode Options -->
+    <string-array name="dark_mode_entries">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>OLED Mode (True Black)</item>
+        <item>System Default</item>
+    </string-array>
+
+    <string-array name="dark_mode_values">
+        <item>light</item>
+        <item>dark</item>
+        <item>oled</item>
+        <item>default</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -90,20 +90,9 @@
             android:key="dark_mode"
             android:title="@string/settings_dark_mode_title"
             android:summary="@string/settings_dark_mode_summary"
-            android:defaultValue="default">
-            <entries>
-                <item>Light</item>
-                <item>Dark</item>
-                <item>OLED Mode (True Black)</item>
-                <item>System Default</item>
-            </entries>
-            <entryValues>
-                <item>light</item>
-                <item>dark</item>
-                <item>oled</item>
-                <item>default</item>
-            </entryValues>
-        </ListPreference>
+            android:entries="@array/dark_mode_entries"
+            android:entryValues="@array/dark_mode_values"
+            android:defaultValue="default" />
 
         <SwitchPreferenceCompat
             android:key="auto_send_whisper"


### PR DESCRIPTION
This commit fixes an InflateException that occurred when opening the Settings screen. The error was caused by incorrectly defining inline <entries> and <entryValues> for the "dark_mode" ListPreference in `root_preferences.xml`.

Changes:
1.  **`app/src/main/res/values/arrays.xml`:**
    - Added `<string-array name="dark_mode_entries">` with user-visible theme names: "Light", "Dark", "OLED Mode (True Black)", "System Default".
    - Added `<string-array name="dark_mode_values">` with corresponding internal values: "light", "dark", "oled", "default".

2.  **`app/src/main/res/xml/root_preferences.xml`:**
    - Modified the `ListPreference` for `android:key="dark_mode"`.
    - Removed the direct child `<entries>` and `<entryValues>` tags.
    - Set `android:entries="@array/dark_mode_entries"` and `android:entryValues="@array/dark_mode_values"` to correctly reference the string arrays.

This resolves the `ClassNotFoundException: androidx.preference.entries` and allows the Settings screen to load correctly with the theme options.