### PR TITLE
Feat: Apply OLED theme dynamically in MainActivity and SettingsActivity

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -147,13 +147,23 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     protected void onCreate(Bundle savedInstanceState) {
         // Initialize settings
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
-        String transcriptionMode = sharedPreferences.getString("transcription_mode", "two_step_transcription"); // Added
+        // String transcriptionMode = sharedPreferences.getString("transcription_mode", "two_step_transcription"); // This line is not needed here for theme application
         
-        // Apply the theme before setting content view
+        // Apply AppCompatDelegate default night mode FIRST
         ThemeManager.applyTheme(sharedPreferences);
+
+        // Then, if OLED is specifically chosen, override with the specific OLED theme
+        String themeValue = sharedPreferences.getString(ThemeManager.PREF_KEY_DARK_MODE, ThemeManager.THEME_DEFAULT);
+        if (ThemeManager.THEME_OLED.equals(themeValue)) {
+            setTheme(R.style.AppTheme_OLED);
+        }
         
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        // Re-fetch transcriptionMode if it was removed above, or ensure it's fetched after setContentView if needed by UI below.
+        // For safety, let's assume it's needed by logic further down in onCreate.
+        String transcriptionMode = sharedPreferences.getString("transcription_mode", "two_step_transcription");
 
         macroExecutor = new MacroExecutor(this); // Initialize MacroExecutor
         macroExecutorService = Executors.newSingleThreadExecutor(); // Initialize ExecutorService

--- a/app/src/main/java/com/drgraff/speakkey/settings/SettingsActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/settings/SettingsActivity.java
@@ -46,6 +46,17 @@ public class SettingsActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+
+        // Apply AppCompatDelegate default night mode FIRST
+        com.drgraff.speakkey.utils.ThemeManager.applyTheme(sharedPreferences);
+
+        // Then, if OLED is specifically chosen, override with the specific OLED theme
+        String themeValue = sharedPreferences.getString(com.drgraff.speakkey.utils.ThemeManager.PREF_KEY_DARK_MODE, com.drgraff.speakkey.utils.ThemeManager.THEME_DEFAULT);
+        if (com.drgraff.speakkey.utils.ThemeManager.THEME_OLED.equals(themeValue)) {
+            setTheme(R.style.AppTheme_OLED);
+        }
+
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_settings);
         
@@ -411,8 +422,13 @@ public class SettingsActivity extends AppCompatActivity {
         
         @Override
         public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-            if (key.equals("dark_mode")) {
-                ThemeManager.applyTheme(sharedPreferences);
+            if (com.drgraff.speakkey.utils.ThemeManager.PREF_KEY_DARK_MODE.equals(key)) {
+                // Apply the theme preference globally via ThemeManager
+                com.drgraff.speakkey.utils.ThemeManager.applyTheme(sharedPreferences);
+                // Recreate the current activity to apply the theme change immediately
+                if (getActivity() != null) {
+                    getActivity().recreate();
+                }
             } else if (key.equals(SettingsActivity.PREF_KEY_ONESTEP_PROCESSING_MODEL) ||
                        key.equals(SettingsActivity.PREF_KEY_TRANSCRIPTION_MODE) ||
                        key.equals(SettingsActivity.PREF_KEY_TWOSTEP_STEP1_ENGINE) ||


### PR DESCRIPTION
This commit implements the dynamic application of the AppTheme.OLED style in MainActivity and SettingsActivity when "oled" is selected in the theme preferences. It also ensures SettingsActivity recreates itself when the theme preference is changed.

Changes:

1.  **`MainActivity.java` (`onCreate()`):**
    - Added logic to read the "dark_mode" SharedPreferences value.
    - If the value is "oled", `setTheme(R.style.AppTheme_OLED)` is called *before* `super.onCreate()`. This is done after the global `ThemeManager.applyTheme()` sets the AppCompatDelegate night mode.

2.  **`SettingsActivity.java`:**
    -   **`onCreate()`**: Similar logic as in MainActivity is added to
        apply `setTheme(R.style.AppTheme_OLED)` if "oled" is selected,
        before `super.onCreate()`.
    -   **`SettingsFragment.onSharedPreferenceChanged()`**: When the
        `ThemeManager.PREF_KEY_DARK_MODE` preference changes,
        `getActivity().recreate()` is now called after
        `ThemeManager.applyTheme()`. This ensures the SettingsActivity
        itself immediately reflects the chosen theme.

This is the first part of applying the OLED theme dynamically across the app. Other activities will require similar modifications to their `onCreate` methods if they don't share a common base activity where this logic can be centralized.