### PR TITLE
Fix: Resolve lambda capture error for sharedPreferences in PromptsAct…

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/data/PromptsActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/data/PromptsActivity.java
@@ -93,10 +93,12 @@ public class PromptsActivity extends AppCompatActivity implements PromptsAdapter
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        // Theme application logic
-        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
-        com.drgraff.speakkey.utils.ThemeManager.applyTheme(sharedPreferences);
-        String themeValue = sharedPreferences.getString(com.drgraff.speakkey.utils.ThemeManager.PREF_KEY_DARK_MODE, com.drgraff.speakkey.utils.ThemeManager.THEME_DEFAULT);
+        // Initialize MEMBER sharedPreferences ONCE at the top
+        this.sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+
+        // Theme application logic uses the MEMBER variable
+        com.drgraff.speakkey.utils.ThemeManager.applyTheme(this.sharedPreferences);
+        String themeValue = this.sharedPreferences.getString(com.drgraff.speakkey.utils.ThemeManager.PREF_KEY_DARK_MODE, com.drgraff.speakkey.utils.ThemeManager.THEME_DEFAULT);
         if (com.drgraff.speakkey.utils.ThemeManager.THEME_OLED.equals(themeValue)) {
             setTheme(R.style.AppTheme_OLED);
         }
@@ -112,8 +114,9 @@ public class PromptsActivity extends AppCompatActivity implements PromptsAdapter
             actionBar.setTitle(R.string.prompts_activity_title); // Assuming this string resource exists
         }
 
-        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
-        String apiKey = sharedPreferences.getString("openai_api_key", "");
+        // Member sharedPreferences already initialized at the top.
+        // String apiKey = sharedPreferences.getString("openai_api_key", ""); // This would now use the member
+        String apiKey = this.sharedPreferences.getString("openai_api_key", ""); // Explicit this for clarity
         // Initialize chatGptApi without a default model for this screen, as each section has its own
         chatGptApi = new ChatGptApi(apiKey, ""); // Model will be set based on spinner/section
 


### PR DESCRIPTION
…ivity

This commit fixes a build error in `PromptsActivity.java`: "local variables referenced from an inner class must be final or effectively final". This error occurred because of how the `sharedPreferences` variable was handled within the `onCreate` method, particularly in relation to its use in spinner item selection listeners.

Changes in `PromptsActivity.onCreate()`:
- Ensured the `sharedPreferences` member variable is initialized once at the beginning of the method using `this.sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);`.
- Removed a local `SharedPreferences sharedPreferences` declaration that was part of the theme application logic, which was shadowing the member variable.
- Removed a subsequent redundant assignment to the member `sharedPreferences` variable.

This ensures that the `sharedPreferences` instance used by the theme logic and later by spinner listeners is the same, correctly initialized member variable, making it effectively final for the listeners and resolving the compilation error.