### PR TITLE
Fix: Resolve lambda capture errors for sharedPreferences in multiple …

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
@@ -105,10 +105,12 @@ public class PhotosActivity extends AppCompatActivity implements FullScreenEditT
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        // Theme application logic
-        android.content.SharedPreferences sharedPreferences = androidx.preference.PreferenceManager.getDefaultSharedPreferences(this);
-        com.drgraff.speakkey.utils.ThemeManager.applyTheme(sharedPreferences);
-        String themeValue = sharedPreferences.getString(com.drgraff.speakkey.utils.ThemeManager.PREF_KEY_DARK_MODE, com.drgraff.speakkey.utils.ThemeManager.THEME_DEFAULT);
+        // Initialize MEMBER sharedPreferences ONCE at the top
+        this.sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+
+        // Theme application logic uses the MEMBER variable
+        com.drgraff.speakkey.utils.ThemeManager.applyTheme(this.sharedPreferences); // Or just sharedPreferences
+        String themeValue = this.sharedPreferences.getString(com.drgraff.speakkey.utils.ThemeManager.PREF_KEY_DARK_MODE, com.drgraff.speakkey.utils.ThemeManager.THEME_DEFAULT);
         if (com.drgraff.speakkey.utils.ThemeManager.THEME_OLED.equals(themeValue)) {
             setTheme(R.style.AppTheme_OLED);
         }
@@ -134,7 +136,8 @@ public class PhotosActivity extends AppCompatActivity implements FullScreenEditT
 
         btnSendToChatGptPhoto = findViewById(R.id.btn_send_to_chatgpt_photo);
         editTextChatGptResponsePhoto = findViewById(R.id.edittext_chatgpt_response_photo);
-        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+        // Member sharedPreferences is already initialized at the top.
+        // This line is redundant: sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
         chkAutoSendChatGptPhoto = findViewById(R.id.chk_auto_send_chatgpt_photo);
         btnClearChatGptResponsePhoto = findViewById(R.id.btn_clear_chatgpt_response_photo);
         btnShareChatGptResponsePhoto = findViewById(R.id.btn_share_chatgpt_response_photo); // Initialize share button
@@ -160,18 +163,18 @@ public class PhotosActivity extends AppCompatActivity implements FullScreenEditT
         progressDialog.setMessage(getString(R.string.photos_progress_sending_to_chatgpt_message));
         progressDialog.setCancelable(false);
 
-        chkAutoSendChatGptPhoto.setChecked(sharedPreferences.getBoolean(PREF_AUTO_SEND_CHATGPT_PHOTO, false));
+        chkAutoSendChatGptPhoto.setChecked(this.sharedPreferences.getBoolean(PREF_AUTO_SEND_CHATGPT_PHOTO, false));
         chkAutoSendChatGptPhoto.setOnCheckedChangeListener((buttonView, isChecked) -> {
-            sharedPreferences.edit().putBoolean(PREF_AUTO_SEND_CHATGPT_PHOTO, isChecked).apply();
+            this.sharedPreferences.edit().putBoolean(PREF_AUTO_SEND_CHATGPT_PHOTO, isChecked).apply();
         });
 
         btnClearChatGptResponsePhoto.setOnClickListener(v -> {
             editTextChatGptResponsePhoto.setText("");
         });
 
-        chkAutoSendInputStickPhoto.setChecked(sharedPreferences.getBoolean(PREF_AUTO_SEND_INPUTSTICK_PHOTO, false)); // Added
+        chkAutoSendInputStickPhoto.setChecked(this.sharedPreferences.getBoolean(PREF_AUTO_SEND_INPUTSTICK_PHOTO, false)); // Added
         chkAutoSendInputStickPhoto.setOnCheckedChangeListener((buttonView, isChecked) -> { // Added
-            sharedPreferences.edit().putBoolean(PREF_AUTO_SEND_INPUTSTICK_PHOTO, isChecked).apply();
+            this.sharedPreferences.edit().putBoolean(PREF_AUTO_SEND_INPUTSTICK_PHOTO, isChecked).apply();
         });
 
         btnSendToInputStickPhoto.setOnClickListener(v -> {


### PR DESCRIPTION
…activities

This commit fixes build errors ("local variables referenced from a lambda expression must be final or effectively final") that occurred in several activities (`PhotosActivity`, `PromptsActivity`, etc.) after theme application logic was added to their `onCreate` methods.

The error was caused by incorrect handling of the `sharedPreferences` variable, where a local declaration in the theme setup code shadowed the activity's member variable, leading to capture issues for listeners (e.g., CheckBox or Spinner listeners) defined later.

Changes in `onCreate()` methods of affected activities:
- Ensured the `sharedPreferences` member variable is initialized once at the beginning of the method using `this.sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);`.
- Removed any local `SharedPreferences sharedPreferences` declarations that were part of the theme application logic.
- Removed any subsequent redundant assignments to the member `sharedPreferences` variable.
- Ensured that all uses of `sharedPreferences` within `onCreate`, including in listeners, now correctly and unambiguously refer to the initialized member variable.

This provides a consistent and correct way of handling SharedPreferences access within these activities, resolving the compilation errors.