### PR TITLE
Feat: Complete Phase 1 of OLED Theming and Toolbar Standardization

### DIFF
--- a/app/src/main/java/com/speakkey/ui/macros/MacroEditorActivity.kt
+++ b/app/src/main/java/com/speakkey/ui/macros/MacroEditorActivity.kt
@@ -44,8 +44,21 @@ class MacroEditorActivity : AppCompatActivity() {
     private val currentActions = mutableListOf<MacroAction>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Theme application logic
+        val sharedPreferences = androidx.preference.PreferenceManager.getDefaultSharedPreferences(this)
+        com.drgraff.speakkey.utils.ThemeManager.applyTheme(sharedPreferences)
+        val themeValue = sharedPreferences.getString(com.drgraff.speakkey.utils.ThemeManager.PREF_KEY_DARK_MODE, com.drgraff.speakkey.utils.ThemeManager.THEME_DEFAULT)
+        if (com.drgraff.speakkey.utils.ThemeManager.THEME_OLED == themeValue) {
+            setTheme(com.drgraff.speakkey.R.style.AppTheme_OLED)
+        }
+
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_edit_macro)
+        setContentView(com.drgraff.speakkey.R.layout.activity_edit_macro)
+
+        val toolbar: androidx.appcompat.widget.Toolbar = findViewById(com.drgraff.speakkey.R.id.toolbar)
+        setSupportActionBar(toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        // Title is set later based on new/edit mode
 
         macroRepository = MacroRepository(applicationContext)
 
@@ -65,10 +78,10 @@ class MacroEditorActivity : AppCompatActivity() {
                 editMacroName.setText(it.name)
                 currentActions.addAll(it.actions)
                 // actionsAdapter.submitList(currentActions) // submitList is called in setupRecyclerView
-                supportActionBar?.title = "Edit Macro"
+                supportActionBar?.title = "Edit Macro" // This will apply to the new toolbar
             }
         } else {
-            supportActionBar?.title = "Create New Macro"
+            supportActionBar?.title = "Create New Macro" // This will apply to the new toolbar
         }
         updateActionsEmptyState() // Initial check
 

--- a/app/src/main/java/com/speakkey/ui/macros/MacroListActivity.kt
+++ b/app/src/main/java/com/speakkey/ui/macros/MacroListActivity.kt
@@ -37,8 +37,16 @@ class MacroListActivity : AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Theme application logic
+        val sharedPreferences = androidx.preference.PreferenceManager.getDefaultSharedPreferences(this)
+        com.drgraff.speakkey.utils.ThemeManager.applyTheme(sharedPreferences) // Ensure ThemeManager is correctly imported or fully qualified
+        val themeValue = sharedPreferences.getString(com.drgraff.speakkey.utils.ThemeManager.PREF_KEY_DARK_MODE, com.drgraff.speakkey.utils.ThemeManager.THEME_DEFAULT)
+        if (com.drgraff.speakkey.utils.ThemeManager.THEME_OLED == themeValue) {
+            setTheme(com.drgraff.speakkey.R.style.AppTheme_OLED) // Ensure R is correctly imported or fully qualified
+        }
+
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_macros)
+        setContentView(com.drgraff.speakkey.R.layout.activity_macros) // Ensure R is correctly imported or fully qualified
 
         val toolbar: androidx.appcompat.widget.Toolbar = findViewById(R.id.toolbar_macros)
         setSupportActionBar(toolbar)

--- a/app/src/main/res/layout/activity_edit_macro.xml
+++ b/app/src/main/res/layout/activity_edit_macro.xml
@@ -1,145 +1,165 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fillViewport="true">
+    android:orientation="vertical"
+    tools:context=".ui.macros.MacroEditorActivity">
 
-    <LinearLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:padding="16dp"
-        tools:context=".ui.macros.MacroEditorActivity">
+        android:theme="@style/Theme.SpeakKey.AppBarOverlay">
 
-        <com.google.android.material.textfield.TextInputLayout
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="Macro Name">
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/Theme.SpeakKey.PopupOverlay" />
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/edit_macro_name"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:inputType="textCapWords"
-                android:maxLines="1" />
-        </com.google.android.material.textfield.TextInputLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Actions"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="8dp"
-            style="@style/TextAppearance.MaterialComponents.Subtitle1"/>
-
-        <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:minHeight="150dp">
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/macro_actions_recycler_view"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:nestedScrollingEnabled="false"/> <!-- Important for ScrollView -->
-
-            <TextView
-                android:id="@+id/empty_actions_text_view"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="No actions yet. Add one below."
-                android:layout_gravity="center"
-                android:visibility="gone"
-                tools:visibility="visible"/>
-        </FrameLayout>
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Add Action:"
-            android:layout_marginTop="16dp"
-            style="@style/TextAppearance.MaterialComponents.Subtitle1"/>
-
-        <GridLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:columnCount="3"
-            android:layout_marginTop="8dp">
-
-            <Button
-                android:id="@+id/btn_add_text_action"
-                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                android:layout_width="0dp"
-                android:layout_columnWeight="1"
-                android:layout_height="wrap_content"
-                android:layout_margin="4dp"
-                android:text="Text"/>
-            <Button
-                android:id="@+id/btn_add_special_key_action"
-                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                android:layout_width="0dp"
-                android:layout_columnWeight="1"
-                android:layout_height="wrap_content"
-                android:layout_margin="4dp"
-                android:text="Key"/>
-            <Button
-                android:id="@+id/btn_add_tab_action"
-                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                android:layout_width="0dp"
-                android:layout_columnWeight="1"
-                android:layout_height="wrap_content"
-                android:layout_margin="4dp"
-                android:text="Tab"/>
-            <Button
-                android:id="@+id/btn_add_enter_action"
-                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                android:layout_width="0dp"
-                android:layout_columnWeight="1"
-                android:layout_height="wrap_content"
-                android:layout_margin="4dp"
-                android:text="Enter"/>
-            <Button
-                android:id="@+id/btn_add_delay_action"
-                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                android:layout_width="0dp"
-                android:layout_columnWeight="1"
-                android:layout_height="wrap_content"
-                android:layout_margin="4dp"
-                android:text="Delay"/>
-            <Button
-                android:id="@+id/btn_add_pause_action"
-                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                android:layout_width="0dp"
-                android:layout_columnWeight="1"
-                android:layout_height="wrap_content"
-                android:layout_margin="4dp"
-                android:text="Pause"/>
-        </GridLayout>
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:layout_marginTop="24dp">
+            android:orientation="vertical"
+            android:padding="16dp">
 
-            <Button
-                android:id="@+id/btn_cancel_macro_edit"
-                style="@style/Widget.MaterialComponents.Button.TextButton"
-                android:layout_width="0dp"
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:layout_marginEnd="8dp"
-                android:text="Cancel"/>
+                android:hint="Macro Name">
 
-            <Button
-                android:id="@+id/btn_save_macro"
-                android:layout_width="0dp"
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/edit_macro_name"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textCapWords"
+                    android:maxLines="1" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <TextView
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:layout_marginStart="8dp"
-                android:text="Save Macro"/>
+                android:text="Actions"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="8dp"
+                style="@style/TextAppearance.MaterialComponents.Subtitle1"/>
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:minHeight="150dp">
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/macro_actions_recycler_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:nestedScrollingEnabled="false"/> <!-- Important for ScrollView -->
+
+                <TextView
+                    android:id="@+id/empty_actions_text_view"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="No actions yet. Add one below."
+                    android:layout_gravity="center"
+                    android:visibility="gone"
+                    tools:visibility="visible"/>
+            </FrameLayout>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Add Action:"
+                android:layout_marginTop="16dp"
+                style="@style/TextAppearance.MaterialComponents.Subtitle1"/>
+
+            <GridLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:columnCount="3"
+                android:layout_marginTop="8dp">
+
+                <Button
+                    android:id="@+id/btn_add_text_action"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="0dp"
+                    android:layout_columnWeight="1"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="4dp"
+                    android:text="Text"/>
+                <Button
+                    android:id="@+id/btn_add_special_key_action"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="0dp"
+                    android:layout_columnWeight="1"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="4dp"
+                    android:text="Key"/>
+                <Button
+                    android:id="@+id/btn_add_tab_action"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="0dp"
+                    android:layout_columnWeight="1"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="4dp"
+                    android:text="Tab"/>
+                <Button
+                    android:id="@+id/btn_add_enter_action"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="0dp"
+                    android:layout_columnWeight="1"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="4dp"
+                    android:text="Enter"/>
+                <Button
+                    android:id="@+id/btn_add_delay_action"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="0dp"
+                    android:layout_columnWeight="1"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="4dp"
+                    android:text="Delay"/>
+                <Button
+                    android:id="@+id/btn_add_pause_action"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="0dp"
+                    android:layout_columnWeight="1"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="4dp"
+                    android:text="Pause"/>
+            </GridLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginTop="24dp">
+
+                <Button
+                    android:id="@+id/btn_cancel_macro_edit"
+                    style="@style/Widget.MaterialComponents.Button.TextButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginEnd="8dp"
+                    android:text="Cancel"/>
+
+                <Button
+                    android:id="@+id/btn_save_macro"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="8dp"
+                    android:text="Save Macro"/>
+            </LinearLayout>
         </LinearLayout>
-    </LinearLayout>
-</ScrollView>
+    </ScrollView>
+</LinearLayout>


### PR DESCRIPTION
This commit consolidates all changes related to Phase 1 of the OLED theming implementation. It establishes a consistent approach to themes and Toolbars across all key activities, ensuring they correctly apply Light, Dark, and the new OLED themes.

Key Changes:

1.  **Base Themes to `.NoActionBar` (`themes.xml`):**
    - `Theme.SpeakKey` (main app theme) and `AppTheme.OLED` now both parent from `Theme.MaterialComponents.DayNight.NoActionBar`.
    - This requires activities needing an ActionBar to define their own Toolbar.

2.  **Toolbar Implementation in Activities:**
    - Ensured all key activities (`MainActivity`, `SettingsActivity`, `PromptsActivity`, `PhotosActivity`, editor activities for prompts and macros, `LogActivity`, `AboutActivity`, `FormattingTagsActivity`, `MacroListActivity`) now: a. Include a `<androidx.appcompat.widget.Toolbar>` in their XML layout. (Toolbars were added to `activity_settings.xml`, `activity_log.xml`, and `activity_edit_macro.xml` where missing). b. Call `setSupportActionBar()` in their `onCreate()` method.

3.  **Dynamic Theme Application in All Key Activities:**
    - Standardized logic added to `onCreate()` (before `super.onCreate()`) of all listed activities to: - Call `ThemeManager.applyTheme()` (which sets the `AppCompatDelegate.setDefaultNightMode()`). - Conditionally call `setTheme(R.style.AppTheme_OLED)` if "oled" is the selected theme preference.

4.  **Specific Fixes from Previous Iterations Included:**
    - `SettingsActivity` now correctly recreates on theme change.
    - `AppTheme.OLED` includes `NavigationViewStyle` for theming navigation drawer items.
    - `nav_header_main.xml` background uses `?attr/colorSurface`.
    - Build errors related to `sharedPreferences` capture in lambdas within `PromptsActivity` and `PhotosActivity` have been resolved.

This comprehensive update should fix previous crashes related to ActionBars (`IllegalStateException`), ensure Toolbars are consistently displayed, and make the OLED theme (and other themes) apply correctly across the main parts of the application.