### PR TITLE
Fix: MainActivity now correctly updates its theme

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,7 +43,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.SpeakKey.NoActionBar"
+            android:theme="@style/Theme.SpeakKey"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -79,7 +79,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import android.text.TextUtils; // Added for ellipsize
 
-public class MainActivity extends AppCompatActivity implements NavigationView.OnNavigationItemSelectedListener, FullScreenEditTextDialogFragment.OnSaveListener {
+public class MainActivity extends AppCompatActivity implements NavigationView.OnNavigationItemSelectedListener, FullScreenEditTextDialogFragment.OnSaveListener, SharedPreferences.OnSharedPreferenceChangeListener {
     private static final String TAG = "MainActivity";
     private static final int REQUEST_RECORD_AUDIO_PERMISSION = 200;
     public static final String TRANSCRIPTION_QUEUED_PLACEHOLDER = "[Transcription queued... Tap to refresh]"; // Added
@@ -1369,6 +1369,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     @Override
     protected void onResume() {
         super.onResume();
+        if (sharedPreferences != null) { // Good practice to check
+            sharedPreferences.registerOnSharedPreferenceChangeListener(this);
+        }
         IntentFilter filter = new IntentFilter(UploadService.ACTION_TRANSCRIPTION_COMPLETE);
         LocalBroadcastManager.getInstance(this).registerReceiver(transcriptionReceiver, filter);
         Log.d(TAG, "TranscriptionBroadcastReceiver registered.");
@@ -1394,8 +1397,19 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     @Override
     protected void onPause() {
         super.onPause();
+        if (sharedPreferences != null) { // Good practice to check
+            sharedPreferences.unregisterOnSharedPreferenceChangeListener(this);
+        }
         LocalBroadcastManager.getInstance(this).unregisterReceiver(transcriptionReceiver);
         Log.d(TAG, "TranscriptionBroadcastReceiver unregistered.");
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        if (ThemeManager.PREF_KEY_DARK_MODE.equals(key)) {
+            Log.d(TAG, "Theme preference changed. Recreating MainActivity.");
+            recreate();
+        }
     }
 
     private void updateActivePromptsDisplay() {


### PR DESCRIPTION
MainActivity was not updating its theme correctly after the initial theme was set, particularly when switching between OLED and Dark modes, or from these modes back to Light.

This was due to two issues:
1. MainActivity's theme in AndroidManifest.xml was set to `@style/Theme.SpeakKey.NoActionBar`, which was not DayNight compatible as it lacked a Theme.MaterialComponents.DayNight parent.
2. MainActivity did not listen for theme preference changes to recreate itself, unlike SettingsActivity.

The fix includes:
- Changed MainActivity's theme in AndroidManifest.xml to `@style/Theme.SpeakKey`. This theme is correctly parented from `Theme.MaterialComponents.DayNight.NoActionBar` in both default and night mode configurations.
- Implemented `SharedPreferences.OnSharedPreferenceChangeListener` in MainActivity. When the `PREF_KEY_DARK_MODE` preference changes, MainActivity now calls `recreate()` to apply the new theme.

These changes ensure MainActivity dynamically and correctly reflects the selected theme (Light, Dark, or OLED).