### PR TITLE
Fix: Ensure MainActivity correctly applies theme after preference cha…

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -149,14 +149,21 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
         // String transcriptionMode = sharedPreferences.getString("transcription_mode", "two_step_transcription"); // This line is not needed here for theme application
         
-        // Apply AppCompatDelegate default night mode FIRST
-        ThemeManager.applyTheme(sharedPreferences);
-
-        // Then, if OLED is specifically chosen, override with the specific OLED theme
+        // Determine the theme value from preferences
         String themeValue = sharedPreferences.getString(ThemeManager.PREF_KEY_DARK_MODE, ThemeManager.THEME_DEFAULT);
+
+        // Set the specific Activity theme (OLED or base SpeakKey theme) FIRST
         if (ThemeManager.THEME_OLED.equals(themeValue)) {
             setTheme(R.style.AppTheme_OLED);
+        } else {
+            // For "light", "dark", or "default", explicitly set Theme.SpeakKey.
+            // Theme.SpeakKey is DayNight aware and will respect the mode set by ThemeManager.applyTheme().
+            setTheme(R.style.Theme_SpeakKey);
         }
+
+        // Then, apply the global AppCompatDelegate night mode (e.g., MODE_NIGHT_YES/NO).
+        // The theme set above will use this mode to pick its final resources.
+        ThemeManager.applyTheme(sharedPreferences);
         
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);


### PR DESCRIPTION
…nges

This commit refines the theme application logic in MainActivity's onCreate method to robustly handle transitions between all theme states (Light, Dark, and OLED).

Previously, MainActivity might not have correctly switched to OLED mode if the preceding mode was Dark, or vice-versa. This was suspected to be due to the order of operations between setting the global AppCompatDelegate night mode and setting the explicit Activity theme.

The fix reorders these operations in `MainActivity.onCreate()`:
1. The specific Activity theme (`R.style.AppTheme_OLED` or `R.style.Theme_SpeakKey`) is now set using `setTheme()` *before* `ThemeManager.applyTheme()` is called.
2. `ThemeManager.applyTheme()` then sets the `AppCompatDelegate.setDefaultNightMode()`. The already-set theme, being DayNight compatible, will respect this mode.

This ensures that the Activity's style is explicitly defined for each onCreate lifecycle, and then adjusted for day/night mode, which should resolve the observed issue where MainActivity would get stuck in a previous theme.