### PR TITLE
Fix: Refine MainActivity theme logic for robust updates

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -152,18 +152,16 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         // Determine the theme value from preferences
         String themeValue = sharedPreferences.getString(ThemeManager.PREF_KEY_DARK_MODE, ThemeManager.THEME_DEFAULT);
 
-        // Set the specific Activity theme (OLED or base SpeakKey theme) FIRST
+        // Apply the global AppCompatDelegate night mode (e.g., MODE_NIGHT_YES/NO) first.
+        ThemeManager.applyTheme(sharedPreferences);
+
+        // ONLY if OLED is specifically chosen, explicitly set the AppTheme.OLED.
+        // Otherwise, the Activity will use its manifest theme (@style/Theme.SpeakKey),
+        // which is DayNight aware and will respect the mode set by ThemeManager.applyTheme().
         if (ThemeManager.THEME_OLED.equals(themeValue)) {
             setTheme(R.style.AppTheme_OLED);
-        } else {
-            // For "light", "dark", or "default", explicitly set Theme.SpeakKey.
-            // Theme.SpeakKey is DayNight aware and will respect the mode set by ThemeManager.applyTheme().
-            setTheme(R.style.Theme_SpeakKey);
         }
-
-        // Then, apply the global AppCompatDelegate night mode (e.g., MODE_NIGHT_YES/NO).
-        // The theme set above will use this mode to pick its final resources.
-        ThemeManager.applyTheme(sharedPreferences);
+        // NO 'else' block calling setTheme(R.style.Theme_SpeakKey)
         
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);


### PR DESCRIPTION
This commit further refines the theme application logic in MainActivity's onCreate method to ensure correct theme transitions between Light, Dark, and OLED modes, addressing a persistent issue where MainActivity would not update correctly if not switching from Light mode.

The updated logic in `MainActivity.onCreate()` is now:
1. The global `AppCompatDelegate.setDefaultNightMode()` is set by calling `ThemeManager.applyTheme()`.
2. An `if` condition checks if the "oled" theme is selected. Only if true, `setTheme(R.style.AppTheme_OLED)` is called.
3. If "oled" is not selected, no explicit `setTheme()` is called in `MainActivity`. Instead, the activity relies on its manifest-defined theme (`@style/Theme.SpeakKey`). This theme is DayNight-aware and will respect the mode set by `ThemeManager.applyTheme()`.

This approach aligns MainActivity's theming strategy more closely with standard Android practices and the behavior of SettingsActivity (which was theming correctly). It simplifies the logic by removing an unnecessary `else` condition that explicitly set `Theme.SpeakKey`, allowing the manifest theme to take precedence for default DayNight behavior. This should resolve the issues you encountered when switching between Dark and OLED modes.