### PR TITLE
feat: Implement user-configurable OLED colors (Part 2)

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/settings/ColorPickerPreference.java
+++ b/app/src/main/java/com/drgraff/speakkey/settings/ColorPickerPreference.java
@@ -13,6 +13,7 @@ import androidx.preference.Preference;
 import androidx.preference.PreferenceViewHolder;
 
 import com.drgraff.speakkey.R; // For R.layout.pref_color_picker
+import android.content.DialogInterface; // Added for android.content.DialogInterface
 import com.flask.colorpicker.ColorPickerView;
 import com.flask.colorpicker.OnColorSelectedListener;
 import com.flask.colorpicker.builder.ColorPickerClickListener;
@@ -124,14 +125,14 @@ public class ColorPickerPreference extends Preference {
                 })
                 .setPositiveButton("OK", new ColorPickerClickListener() {
                     @Override
-                    public void onClick(com.flask.colorpicker.DialogInterface d, int lastSelectedColor, Integer[] allColors) {
+                        public void onClick(DialogInterface d, int lastSelectedColor, Integer[] allColors) { // d is now android.content.DialogInterface
                         saveColor(lastSelectedColor);
                         updateColorPreview(); // Make sure preview updates
                     }
                 })
-                .setNegativeButton("Cancel", new com.flask.colorpicker.DialogInterface.OnClickListener() {
+                    .setNegativeButton("Cancel", new DialogInterface.OnClickListener() { // Uses android.content.DialogInterface
                     @Override
-                    public void onClick(com.flask.colorpicker.DialogInterface d, int i) {
+                        public void onClick(DialogInterface d, int i) { // d is android.content.DialogInterface
                         d.dismiss();
                     }
                 })

--- a/app/src/main/java/com/drgraff/speakkey/utils/DynamicThemeApplicator.java
+++ b/app/src/main/java/com/drgraff/speakkey/utils/DynamicThemeApplicator.java
@@ -20,7 +20,7 @@ public class DynamicThemeApplicator {
     public static final int DEFAULT_OLED_TEXT_PRIMARY = Color.parseColor("#FFFFFF");
     // public static final int DEFAULT_OLED_TEXT_SECONDARY = Color.parseColor("#AAAAAA"); // Currently unused
     public static final int DEFAULT_OLED_ICON_TINT = Color.parseColor("#FFFFFF");
-    // public static final int DEFAULT_OLED_EDIT_TEXT_BACKGROUND = Color.parseColor("#1A1A1A"); // Currently unused
+    public static final int DEFAULT_OLED_EDIT_TEXT_BACKGROUND = Color.parseColor("#1A1A1A");
 
     public static void applyOledColors(Activity activity, SharedPreferences prefs) {
         if (activity == null || prefs == null) {
@@ -35,6 +35,9 @@ public class DynamicThemeApplicator {
 
         activity.getWindow().setStatusBarColor(oledBackgroundColor);
         activity.getWindow().setNavigationBarColor(oledBackgroundColor);
+
+        // Explicitly set window background
+        activity.getWindow().getDecorView().setBackgroundColor(oledBackgroundColor);
 
         // Assuming the activity has a Toolbar with id R.id.toolbar
         // This is a common convention but might need to be made more flexible if not all activities use this ID.


### PR DESCRIPTION
This commit builds upon the initial framework for user-configurable OLED colors and completes the planned implementation.

Key changes include:

1.  **Expanded `OnSharedPreferenceChangeListener`:**
    - Modified `SettingsActivity.SettingsFragment` and `MainActivity` to listen for changes in any of the `pref_oled_color_*` SharedPreferences keys.
    - If an OLED color preference changes while the OLED theme is active, the respective activity will now `recreate()` itself, causing the `DynamicThemeApplicator` to apply the new custom color.

2.  **Extended Dynamic Color Application:**
    - `DynamicThemeApplicator.applyOledColors()` was updated to also explicitly set the main window background color using the custom `oled_background_color` preference.
    - In `MainActivity`, after `DynamicThemeApplicator` is called, specific logic was added to set the background color of the `whisperText` and `chatGptText` EditTexts using the `pref_oled_edit_text_background` custom color. The initialization order in `MainActivity.onCreate` was also verified to ensure UI elements are available before styling.

3.  **Build Fix:**
    - Corrected `DialogInterface` usage in `ColorPickerPreference.java` to use `android.content.DialogInterface` for all dialog listener callbacks, resolving previous build errors.

With these changes, you can now select custom colors for various OLED theme attributes via `SettingsActivity`, and these colors will be dynamically applied to `MainActivity` and `SettingsActivity` for elements like the Toolbar, status/navigation bars, window background, and specific EditText backgrounds. The activities will also auto-update if these colors are changed while the app is running.

The known `MainActivity` theming bug (related to switching between Dark and OLED modes) remains an separate, unresolved issue.