### PR TITLE
Fix: Toolbar background now uses custom 'Primary Color' in OLED mode

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/utils/DynamicThemeApplicator.java
+++ b/app/src/main/java/com/drgraff/speakkey/utils/DynamicThemeApplicator.java
@@ -58,12 +58,14 @@ public class DynamicThemeApplicator {
         Toolbar toolbar = activity.findViewById(R.id.toolbar);
         if (toolbar != null) {
             Log.d(TAG, "Toolbar found, applying colors."); // Removed current background as it might be complex object
-            toolbar.setBackgroundColor(oledSurfaceColor);
+            // Use primaryOledColor for the Toolbar background
+            toolbar.setBackgroundColor(primaryOledColor);
             toolbar.setTitleTextColor(oledTextColorPrimary);
             if (toolbar.getNavigationIcon() != null) {
                 toolbar.getNavigationIcon().setColorFilter(oledIconTintColor, PorterDuff.Mode.SRC_ATOP);
             }
-            Log.d(TAG, String.format("Toolbar colors applied. New Toolbar BG color: 0x%08X", oledSurfaceColor));
+            // Log the primaryOledColor that was applied to the background
+            Log.d(TAG, String.format("Toolbar colors applied. New Toolbar BG color: 0x%08X", primaryOledColor));
         } else {
             Log.w(TAG, "Toolbar not found (R.id.toolbar). Cannot apply toolbar specific colors.");
         }


### PR DESCRIPTION
This commit corrects an issue in the user-configurable OLED colors feature where the Toolbar background was not using the color selected by you in the "Primary Color" preference (`pref_oled_color_primary`). Instead, it was incorrectly using the "Surface Color" (`pref_oled_color_surface`).

The `DynamicThemeApplicator.applyOledColors` method has been modified to set the Toolbar's background color using the `primaryOledColor` variable, which is correctly populated from the `pref_oled_color_primary` SharedPreferences value. The relevant log message was also updated to reflect this change.

With this fix, when you select a custom "Primary Color" in the OLED theme settings, the Toolbar background in `SettingsActivity` and `MainActivity` (when in OLED mode) will now correctly display the chosen primary color. Other customizable colors (status bar, window background, text/icon colors) remain controlled by their respective preferences.