### PR TITLE
feat: Enable dynamic coloring of Start Recording button in OLED mode

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -64,6 +64,7 @@ import com.drgraff.speakkey.utils.AppLogManager;
 import com.drgraff.speakkey.utils.ThemeManager;
 import com.drgraff.speakkey.utils.DynamicThemeApplicator; // Added for DynamicThemeApplicator
 import com.google.android.material.navigation.NavigationView;
+import android.content.res.ColorStateList; // Added for ColorStateList
 
 import com.hualee.lame.LameControl;
 
@@ -184,6 +185,22 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             }
             if (chatGptText != null) {
                 chatGptText.setBackgroundColor(oledEditTextBackgroundColor);
+            }
+
+            // Style btnStartRecording
+            if (btnStartRecording != null) { // btnStartRecording is a field initialized in initializeUiElements()
+                int primaryOledColor = sharedPreferences.getInt(
+                    "pref_oled_color_primary",
+                    DynamicThemeApplicator.DEFAULT_OLED_PRIMARY
+                );
+                int onPrimaryOledColor = sharedPreferences.getInt(
+                    "pref_oled_color_on_primary",
+                    DynamicThemeApplicator.DEFAULT_OLED_ON_PRIMARY
+                );
+
+                btnStartRecording.setBackgroundTintList(ColorStateList.valueOf(primaryOledColor));
+                btnStartRecording.setTextColor(onPrimaryOledColor);
+                Log.d(TAG, String.format("MainActivity: Styled btnStartRecording with BG=0x%08X, Text=0x%08X", primaryOledColor, onPrimaryOledColor));
             }
         }
 
@@ -1470,10 +1487,15 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
         final String[] oledColorKeys = {
-            "pref_oled_color_primary", "pref_oled_color_secondary",
-            "pref_oled_color_background", "pref_oled_color_surface",
-            "pref_oled_color_text_primary", "pref_oled_color_text_secondary",
-            "pref_oled_color_icon_tint", "pref_oled_color_edit_text_background"
+            "pref_oled_color_primary",
+            "pref_oled_color_on_primary", // New key added
+            "pref_oled_color_secondary",
+            "pref_oled_color_background",
+            "pref_oled_color_surface",
+            "pref_oled_color_text_primary",
+            "pref_oled_color_text_secondary",
+            "pref_oled_color_icon_tint",
+            "pref_oled_color_edit_text_background"
         };
         boolean isOledColorKey = false;
         for (String oledKey : oledColorKeys) {

--- a/app/src/main/java/com/drgraff/speakkey/settings/SettingsActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/settings/SettingsActivity.java
@@ -133,16 +133,29 @@ public class SettingsActivity extends AppCompatActivity {
             }
 
             // Set default colors for OLED ColorPickerPreferences
-            String[] oledColorKeys = {
-                "pref_oled_color_primary", "pref_oled_color_secondary",
-                "pref_oled_color_background", "pref_oled_color_surface",
-                "pref_oled_color_text_primary", "pref_oled_color_text_secondary",
-                "pref_oled_color_icon_tint", "pref_oled_color_edit_text_background"
+            final String[] oledColorKeys = {
+                "pref_oled_color_primary",
+                "pref_oled_color_on_primary", // New
+                "pref_oled_color_secondary",
+                "pref_oled_color_background",
+                "pref_oled_color_surface",
+                "pref_oled_color_text_primary",
+                "pref_oled_color_text_secondary",
+                "pref_oled_color_icon_tint",
+                "pref_oled_color_edit_text_background"
             };
 
-            String[] oledDefaultColorsHex = {
-                "#03DAC6", "#03DAC6", "#000000", "#0D0D0D",
-                "#FFFFFF", "#AAAAAA", "#FFFFFF", "#1A1A1A"
+            // Corresponding default hex values
+            final String[] oledDefaultColorsHex = {
+                "#03DAC6", // primary (Cyan)
+                "#000000", // on_primary (Black) - NEW
+                "#03DAC6", // secondary (Cyan)
+                "#000000", // background (Black)
+                "#0D0D0D", // surface (Dark Grey)
+                "#FFFFFF", // text_primary (White)
+                "#AAAAAA", // text_secondary (Light Grey)
+                "#FFFFFF", // icon_tint (White)
+                "#1A1A1A"  // edit_text_background (Darker Grey)
             };
 
             for (int i = 0; i < oledColorKeys.length; i++) {

--- a/app/src/main/java/com/drgraff/speakkey/utils/DynamicThemeApplicator.java
+++ b/app/src/main/java/com/drgraff/speakkey/utils/DynamicThemeApplicator.java
@@ -5,10 +5,10 @@ import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.util.Log;
-import android.view.View; // Keep this import, it's used by activity.getWindow().getDecorView()
+import android.view.View;
 import androidx.appcompat.widget.Toolbar;
 
-import com.drgraff.speakkey.R; // For R.id.toolbar
+import com.drgraff.speakkey.R;
 
 public class DynamicThemeApplicator {
     private static final String TAG = "DynamicThemeApplicator";
@@ -19,6 +19,7 @@ public class DynamicThemeApplicator {
     public static final int DEFAULT_OLED_BACKGROUND = Color.parseColor("#000000");
     public static final int DEFAULT_OLED_SURFACE = Color.parseColor("#0D0D0D");
     public static final int DEFAULT_OLED_TEXT_PRIMARY = Color.parseColor("#FFFFFF");
+    public static final int DEFAULT_OLED_ON_PRIMARY = Color.parseColor("#000000"); // Black - Corrected: defined once
     public static final int DEFAULT_OLED_ICON_TINT = Color.parseColor("#FFFFFF");
     public static final int DEFAULT_OLED_EDIT_TEXT_BACKGROUND = Color.parseColor("#1A1A1A");
 
@@ -39,6 +40,10 @@ public class DynamicThemeApplicator {
         int oledTextColorPrimary = prefs.getInt("pref_oled_color_text_primary", DEFAULT_OLED_TEXT_PRIMARY);
         Log.d(TAG, String.format("pref_oled_color_text_primary: Value=0x%08X, Default=0x%08X", oledTextColorPrimary, DEFAULT_OLED_TEXT_PRIMARY));
 
+        // Logging for on_primary
+        int oledOnPrimaryColor = prefs.getInt("pref_oled_color_on_primary", DEFAULT_OLED_ON_PRIMARY);
+        Log.d(TAG, String.format("pref_oled_color_on_primary: Value=0x%08X, Default=0x%08X", oledOnPrimaryColor, DEFAULT_OLED_ON_PRIMARY));
+
         int oledIconTintColor = prefs.getInt("pref_oled_color_icon_tint", DEFAULT_OLED_ICON_TINT);
         Log.d(TAG, String.format("pref_oled_color_icon_tint: Value=0x%08X, Default=0x%08X", oledIconTintColor, DEFAULT_OLED_ICON_TINT));
 
@@ -57,18 +62,18 @@ public class DynamicThemeApplicator {
 
         Toolbar toolbar = activity.findViewById(R.id.toolbar);
         if (toolbar != null) {
-            Log.d(TAG, "Toolbar found, applying colors."); // Removed current background as it might be complex object
-            // Use primaryOledColor for the Toolbar background
+            Log.d(TAG, "Toolbar found, applying colors.");
             toolbar.setBackgroundColor(primaryOledColor);
             toolbar.setTitleTextColor(oledTextColorPrimary);
+            // Potentially set subtitle text color if used: toolbar.setSubtitleTextColor(oledOnPrimaryColor);
+            // Potentially set menu item icon tints if needed, though this is complex here.
             if (toolbar.getNavigationIcon() != null) {
-                toolbar.getNavigationIcon().setColorFilter(oledIconTintColor, PorterDuff.Mode.SRC_ATOP);
+                toolbar.getNavigationIcon().setColorFilter(oledOnPrimaryColor, PorterDuff.Mode.SRC_ATOP); // Use onPrimary for nav icon
             }
-            // Log the primaryOledColor that was applied to the background
             Log.d(TAG, String.format("Toolbar colors applied. New Toolbar BG color: 0x%08X", primaryOledColor));
         } else {
             Log.w(TAG, "Toolbar not found (R.id.toolbar). Cannot apply toolbar specific colors.");
         }
         Log.d(TAG, "Finished applying custom OLED colors.");
-    } // End of applyOledColors method
-} // End of DynamicThemeApplicator class
+    }
+}

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -115,6 +115,11 @@
             android:summary="Set the primary color for OLED mode" />
 
         <com.drgraff.speakkey.settings.ColorPickerPreference
+            android:key="pref_oled_color_on_primary"
+            android:title="On Primary Color"
+            android:summary="Set the text/icon color for elements using Primary Color as background" />
+
+        <com.drgraff.speakkey.settings.ColorPickerPreference
             android:key="pref_oled_color_secondary"
             android:title="Secondary/Accent Color"
             android:summary="Set the secondary/accent color for OLED mode" />


### PR DESCRIPTION
This commit introduces customization for button colors in OLED mode, specifically targeting the 'Start Recording' button in MainActivity. It also adds a new customizable 'On Primary Color' for OLED themes.

Key changes:

1.  **Added 'On Primary Color' Preference:**
    - A new SharedPreferences key `pref_oled_color_on_primary` was defined.
    - `DynamicThemeApplicator.java` now includes a `DEFAULT_OLED_ON_PRIMARY` constant (defaulting to Black for contrast with the Cyan default primary).
    - A `ColorPickerPreference` for "On Primary Color" was added to `root_preferences.xml` and initialized in `SettingsActivity.SettingsFragment`.
    - Logging for this new color was added to `DynamicThemeApplicator`.
    - `DynamicThemeApplicator` was updated to use this 'On Primary Color' for the Toolbar's navigation icon tint, providing better contrast if the primary color (Toolbar background) is light.

2.  **Dynamic Styling for 'Start Recording' Button:**
    - In `MainActivity.onCreate()`, when the OLED theme is active, the `btnStartRecording` MaterialButton is now dynamically styled: - Its background tint is set using the user-defined `pref_oled_color_primary`. - Its text color is set using the user-defined `pref_oled_color_on_primary`.

3.  **Updated Preference Change Listener:**
    - `MainActivity.onSharedPreferenceChanged()` was updated to include `pref_oled_color_on_primary` in the list of OLED color keys. Changes to this preference (while OLED mode is active) will now trigger a `recreate()` of `MainActivity`, ensuring the button text color updates.

This allows you to customize the main action button's background and text color in OLED mode, enhancing theme personalization.