### PR TITLE
feat: Refactor OLED color settings into descriptive groups

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -176,41 +176,36 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         if (ThemeManager.THEME_OLED.equals(themeValue)) {
             DynamicThemeApplicator.applyOledColors(this, sharedPreferences); // Applies to Toolbar, Window
 
-            int oledEditTextBackgroundColor = sharedPreferences.getInt(
-                "pref_oled_edit_text_background",
-                DynamicThemeApplicator.DEFAULT_OLED_EDIT_TEXT_BACKGROUND
+            // Style EditText backgrounds
+            int textboxBackgroundColor = sharedPreferences.getInt(
+                "pref_oled_textbox_background",
+                DynamicThemeApplicator.DEFAULT_OLED_TEXTBOX_BACKGROUND
             );
             if (whisperText != null) {
-                whisperText.setBackgroundColor(oledEditTextBackgroundColor);
+                whisperText.setBackgroundColor(textboxBackgroundColor);
+                Log.d(TAG, String.format("MainActivity: Styled whisperText BG: 0x%08X", textboxBackgroundColor));
             }
             if (chatGptText != null) {
-                chatGptText.setBackgroundColor(oledEditTextBackgroundColor);
+                chatGptText.setBackgroundColor(textboxBackgroundColor);
+                Log.d(TAG, String.format("MainActivity: Styled chatGptText BG: 0x%08X", textboxBackgroundColor));
             }
 
-            // Retrieve colors once
-            int primaryOledColor = sharedPreferences.getInt(
-                "pref_oled_color_primary",
-                DynamicThemeApplicator.DEFAULT_OLED_PRIMARY
+            // Style Action Buttons
+            int buttonBackgroundColor = sharedPreferences.getInt(
+                "pref_oled_button_background",
+                DynamicThemeApplicator.DEFAULT_OLED_BUTTON_BACKGROUND
             );
-            int onPrimaryOledColor = sharedPreferences.getInt(
-                "pref_oled_color_on_primary",
-                DynamicThemeApplicator.DEFAULT_OLED_ON_PRIMARY
+            int buttonTextIconColor = sharedPreferences.getInt(
+                "pref_oled_button_text_icon",
+                DynamicThemeApplicator.DEFAULT_OLED_BUTTON_TEXT_ICON
             );
 
-            // Style btnStartRecording
-            if (btnStartRecording != null) { // btnStartRecording is a field initialized in initializeUiElements()
-                btnStartRecording.setBackgroundTintList(ColorStateList.valueOf(primaryOledColor));
-                btnStartRecording.setTextColor(onPrimaryOledColor);
-                Log.d(TAG, String.format("MainActivity: Styled btnStartRecording with BG=0x%08X, Text=0x%08X", primaryOledColor, onPrimaryOledColor));
-            }
-
-            // Style other buttons
-            Button[] buttonsToStyle = { // Changed to Button[]
-                btnPauseRecording, btnStopRecording, btnSendWhisper,
+            Button[] buttonsToStyle = {
+                btnStartRecording, btnPauseRecording, btnStopRecording, btnSendWhisper,
                 btnSendChatGpt, btnSendInputStick, btnSendWhisperToInputStick
             };
             String[] buttonNames = {
-                "btnPauseRecording", "btnStopRecording", "btnSendWhisper",
+                "btnStartRecording", "btnPauseRecording", "btnStopRecording", "btnSendWhisper",
                 "btnSendChatGpt", "btnSendInputStick", "btnSendWhisperToInputStick"
             };
 
@@ -218,11 +213,13 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                 Button button = buttonsToStyle[i];
                 String buttonName = buttonNames[i];
                 if (button != null) {
-                    button.setBackgroundTintList(ColorStateList.valueOf(primaryOledColor));
-                    button.setTextColor(onPrimaryOledColor);
-                    // If buttons have icons that need tinting:
-                    // button.setIconTint(android.content.res.ColorStateList.valueOf(onPrimaryOledColor));
-                    Log.d(TAG, String.format("MainActivity: Styled %s with BG=0x%08X, Text=0x%08X", buttonName, primaryOledColor, onPrimaryOledColor));
+                    button.setBackgroundTintList(ColorStateList.valueOf(buttonBackgroundColor));
+                    button.setTextColor(buttonTextIconColor);
+                    // If buttons have icons that need tinting (assuming MaterialButton or AppCompatButton):
+                    // if (button instanceof com.google.android.material.button.MaterialButton) {
+                    //    ((com.google.android.material.button.MaterialButton) button).setIconTint(ColorStateList.valueOf(buttonTextIconColor));
+                    // }
+                    Log.d(TAG, String.format("MainActivity: Styled %s with BG=0x%08X, Text=0x%08X", buttonName, buttonBackgroundColor, buttonTextIconColor));
                 } else {
                     Log.w(TAG, "MainActivity: Button " + buttonName + " is null, cannot style.");
                 }
@@ -1512,15 +1509,12 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
         final String[] oledColorKeys = {
-            "pref_oled_color_primary",
-            "pref_oled_color_on_primary", // New key added
-            "pref_oled_color_secondary",
-            "pref_oled_color_background",
-            "pref_oled_color_surface",
-            "pref_oled_color_text_primary",
-            "pref_oled_color_text_secondary",
-            "pref_oled_color_icon_tint",
-            "pref_oled_color_edit_text_background"
+            "pref_oled_topbar_background", "pref_oled_topbar_text_icon",
+            "pref_oled_main_background", "pref_oled_surface_background",
+            "pref_oled_general_text_primary", "pref_oled_general_text_secondary",
+            "pref_oled_button_background", "pref_oled_button_text_icon",
+            "pref_oled_textbox_background", "pref_oled_textbox_accent",
+            "pref_oled_accent_general"
         };
         boolean isOledColorKey = false;
         for (String oledKey : oledColorKeys) {

--- a/app/src/main/java/com/drgraff/speakkey/settings/SettingsActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/settings/SettingsActivity.java
@@ -134,28 +134,26 @@ public class SettingsActivity extends AppCompatActivity {
 
             // Set default colors for OLED ColorPickerPreferences
             final String[] oledColorKeys = {
-                "pref_oled_color_primary",
-                "pref_oled_color_on_primary", // New
-                "pref_oled_color_secondary",
-                "pref_oled_color_background",
-                "pref_oled_color_surface",
-                "pref_oled_color_text_primary",
-                "pref_oled_color_text_secondary",
-                "pref_oled_color_icon_tint",
-                "pref_oled_color_edit_text_background"
+                "pref_oled_topbar_background", "pref_oled_topbar_text_icon",
+                "pref_oled_main_background", "pref_oled_surface_background",
+                "pref_oled_general_text_primary", "pref_oled_general_text_secondary",
+                "pref_oled_button_background", "pref_oled_button_text_icon",
+                "pref_oled_textbox_background", "pref_oled_textbox_accent",
+                "pref_oled_accent_general"
             };
 
-            // Corresponding default hex values
             final String[] oledDefaultColorsHex = {
-                "#03DAC6", // primary (Cyan)
-                "#000000", // on_primary (Black) - NEW
-                "#03DAC6", // secondary (Cyan)
-                "#000000", // background (Black)
-                "#0D0D0D", // surface (Dark Grey)
-                "#FFFFFF", // text_primary (White)
-                "#AAAAAA", // text_secondary (Light Grey)
-                "#FFFFFF", // icon_tint (White)
-                "#1A1A1A"  // edit_text_background (Darker Grey)
+                "#03DAC6", // topbar_background (Cyan)
+                "#000000", // topbar_text_icon (Black)
+                "#000000", // main_background (Black)
+                "#0D0D0D", // surface_background (Dark Grey)
+                "#FFFFFF", // general_text_primary (White)
+                "#AAAAAA", // general_text_secondary (Light Grey)
+                "#03DAC6", // button_background (Cyan)
+                "#000000", // button_text_icon (Black)
+                "#1A1A1A", // textbox_background (Darker Grey)
+                "#03DAC6", // textbox_accent (Cyan)
+                "#03DAC6"  // accent_general (Cyan)
             };
 
             for (int i = 0; i < oledColorKeys.length; i++) {
@@ -473,10 +471,12 @@ public class SettingsActivity extends AppCompatActivity {
         @Override
         public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
             final String[] oledColorKeys = {
-                "pref_oled_color_primary", "pref_oled_color_secondary",
-                "pref_oled_color_background", "pref_oled_color_surface",
-                "pref_oled_color_text_primary", "pref_oled_color_text_secondary",
-                "pref_oled_color_icon_tint", "pref_oled_color_edit_text_background"
+                "pref_oled_topbar_background", "pref_oled_topbar_text_icon",
+                "pref_oled_main_background", "pref_oled_surface_background",
+                "pref_oled_general_text_primary", "pref_oled_general_text_secondary",
+                "pref_oled_button_background", "pref_oled_button_text_icon",
+                "pref_oled_textbox_background", "pref_oled_textbox_accent",
+                "pref_oled_accent_general"
             };
             boolean isOledColorKey = false;
             for (String oledKey : oledColorKeys) {

--- a/app/src/main/java/com/drgraff/speakkey/utils/DynamicThemeApplicator.java
+++ b/app/src/main/java/com/drgraff/speakkey/utils/DynamicThemeApplicator.java
@@ -13,15 +13,18 @@ import com.drgraff.speakkey.R;
 public class DynamicThemeApplicator {
     private static final String TAG = "DynamicThemeApplicator";
 
-    // Default color values (ARGB integers)
-    public static final int DEFAULT_OLED_PRIMARY = Color.parseColor("#03DAC6");
-    public static final int DEFAULT_OLED_SECONDARY = Color.parseColor("#03DAC6");
-    public static final int DEFAULT_OLED_BACKGROUND = Color.parseColor("#000000");
-    public static final int DEFAULT_OLED_SURFACE = Color.parseColor("#0D0D0D");
-    public static final int DEFAULT_OLED_TEXT_PRIMARY = Color.parseColor("#FFFFFF");
-    public static final int DEFAULT_OLED_ON_PRIMARY = Color.parseColor("#000000"); // Black - Corrected: defined once
-    public static final int DEFAULT_OLED_ICON_TINT = Color.parseColor("#FFFFFF");
-    public static final int DEFAULT_OLED_EDIT_TEXT_BACKGROUND = Color.parseColor("#1A1A1A");
+    // New Default color values (ARGB integers)
+    public static final int DEFAULT_OLED_TOPBAR_BACKGROUND = Color.parseColor("#03DAC6"); // Cyan
+    public static final int DEFAULT_OLED_TOPBAR_TEXT_ICON = Color.parseColor("#000000");  // Black
+    public static final int DEFAULT_OLED_MAIN_BACKGROUND = Color.parseColor("#000000");   // Black
+    public static final int DEFAULT_OLED_SURFACE_BACKGROUND = Color.parseColor("#0D0D0D"); // Dark Grey
+    public static final int DEFAULT_OLED_GENERAL_TEXT_PRIMARY = Color.parseColor("#FFFFFF"); // White
+    public static final int DEFAULT_OLED_GENERAL_TEXT_SECONDARY = Color.parseColor("#AAAAAA"); // Light Grey
+    public static final int DEFAULT_OLED_BUTTON_BACKGROUND = Color.parseColor("#03DAC6");  // Cyan
+    public static final int DEFAULT_OLED_BUTTON_TEXT_ICON = Color.parseColor("#000000");   // Black
+    public static final int DEFAULT_OLED_TEXTBOX_BACKGROUND = Color.parseColor("#1A1A1A"); // Darker Grey
+    public static final int DEFAULT_OLED_TEXTBOX_ACCENT = Color.parseColor("#03DAC6");    // Cyan
+    public static final int DEFAULT_OLED_ACCENT_GENERAL = Color.parseColor("#03DAC6");      // Cyan
 
     public static void applyOledColors(Activity activity, SharedPreferences prefs) {
         if (activity == null || prefs == null) {
@@ -29,51 +32,60 @@ public class DynamicThemeApplicator {
             return;
         }
 
-        Log.d(TAG, "Applying custom OLED colors...");
+        Log.d(TAG, "Applying custom OLED colors using new grouped keys...");
 
-        int oledBackgroundColor = prefs.getInt("pref_oled_color_background", DEFAULT_OLED_BACKGROUND);
-        Log.d(TAG, String.format("pref_oled_color_background: Value=0x%08X, Default=0x%08X", oledBackgroundColor, DEFAULT_OLED_BACKGROUND));
+        // Retrieve all new grouped preference values
+        int topbarBackgroundColor = prefs.getInt("pref_oled_topbar_background", DEFAULT_OLED_TOPBAR_BACKGROUND);
+        Log.d(TAG, String.format("pref_oled_topbar_background: Value=0x%08X, Default=0x%08X", topbarBackgroundColor, DEFAULT_OLED_TOPBAR_BACKGROUND));
 
-        int oledSurfaceColor = prefs.getInt("pref_oled_color_surface", DEFAULT_OLED_SURFACE);
-        Log.d(TAG, String.format("pref_oled_color_surface: Value=0x%08X, Default=0x%08X", oledSurfaceColor, DEFAULT_OLED_SURFACE));
+        int topbarTextIconColor = prefs.getInt("pref_oled_topbar_text_icon", DEFAULT_OLED_TOPBAR_TEXT_ICON);
+        Log.d(TAG, String.format("pref_oled_topbar_text_icon: Value=0x%08X, Default=0x%08X", topbarTextIconColor, DEFAULT_OLED_TOPBAR_TEXT_ICON));
 
-        int oledTextColorPrimary = prefs.getInt("pref_oled_color_text_primary", DEFAULT_OLED_TEXT_PRIMARY);
-        Log.d(TAG, String.format("pref_oled_color_text_primary: Value=0x%08X, Default=0x%08X", oledTextColorPrimary, DEFAULT_OLED_TEXT_PRIMARY));
+        int mainBackgroundColor = prefs.getInt("pref_oled_main_background", DEFAULT_OLED_MAIN_BACKGROUND);
+        Log.d(TAG, String.format("pref_oled_main_background: Value=0x%08X, Default=0x%08X", mainBackgroundColor, DEFAULT_OLED_MAIN_BACKGROUND));
 
-        // Logging for on_primary
-        int oledOnPrimaryColor = prefs.getInt("pref_oled_color_on_primary", DEFAULT_OLED_ON_PRIMARY);
-        Log.d(TAG, String.format("pref_oled_color_on_primary: Value=0x%08X, Default=0x%08X", oledOnPrimaryColor, DEFAULT_OLED_ON_PRIMARY));
+        int surfaceBackgroundColor = prefs.getInt("pref_oled_surface_background", DEFAULT_OLED_SURFACE_BACKGROUND);
+        Log.d(TAG, String.format("pref_oled_surface_background: Value=0x%08X, Default=0x%08X", surfaceBackgroundColor, DEFAULT_OLED_SURFACE_BACKGROUND));
 
-        int oledIconTintColor = prefs.getInt("pref_oled_color_icon_tint", DEFAULT_OLED_ICON_TINT);
-        Log.d(TAG, String.format("pref_oled_color_icon_tint: Value=0x%08X, Default=0x%08X", oledIconTintColor, DEFAULT_OLED_ICON_TINT));
+        int generalTextPrimaryColor = prefs.getInt("pref_oled_general_text_primary", DEFAULT_OLED_GENERAL_TEXT_PRIMARY);
+        Log.d(TAG, String.format("pref_oled_general_text_primary: Value=0x%08X, Default=0x%08X", generalTextPrimaryColor, DEFAULT_OLED_GENERAL_TEXT_PRIMARY));
 
-        int primaryOledColor = prefs.getInt("pref_oled_color_primary", DEFAULT_OLED_PRIMARY);
-        Log.d(TAG, String.format("pref_oled_color_primary: Value=0x%08X, Default=0x%08X", primaryOledColor, DEFAULT_OLED_PRIMARY));
+        int generalTextSecondaryColor = prefs.getInt("pref_oled_general_text_secondary", DEFAULT_OLED_GENERAL_TEXT_SECONDARY);
+        Log.d(TAG, String.format("pref_oled_general_text_secondary: Value=0x%08X, Default=0x%08X", generalTextSecondaryColor, DEFAULT_OLED_GENERAL_TEXT_SECONDARY));
 
-        int secondaryOledColor = prefs.getInt("pref_oled_color_secondary", DEFAULT_OLED_SECONDARY);
-        Log.d(TAG, String.format("pref_oled_color_secondary: Value=0x%08X, Default=0x%08X", secondaryOledColor, DEFAULT_OLED_SECONDARY));
+        int buttonBackgroundColor = prefs.getInt("pref_oled_button_background", DEFAULT_OLED_BUTTON_BACKGROUND);
+        Log.d(TAG, String.format("pref_oled_button_background: Value=0x%08X, Default=0x%08X", buttonBackgroundColor, DEFAULT_OLED_BUTTON_BACKGROUND));
 
-        int oledEditTextBackgroundColor = prefs.getInt("pref_oled_edit_text_background", DEFAULT_OLED_EDIT_TEXT_BACKGROUND);
-        Log.d(TAG, String.format("pref_oled_edit_text_background: Value=0x%08X, Default=0x%08X", oledEditTextBackgroundColor, DEFAULT_OLED_EDIT_TEXT_BACKGROUND));
+        int buttonTextIconColor = prefs.getInt("pref_oled_button_text_icon", DEFAULT_OLED_BUTTON_TEXT_ICON);
+        Log.d(TAG, String.format("pref_oled_button_text_icon: Value=0x%08X, Default=0x%08X", buttonTextIconColor, DEFAULT_OLED_BUTTON_TEXT_ICON));
 
-        activity.getWindow().setStatusBarColor(oledBackgroundColor);
-        activity.getWindow().setNavigationBarColor(oledBackgroundColor);
-        activity.getWindow().getDecorView().setBackgroundColor(oledBackgroundColor);
+        int textboxBackgroundColor = prefs.getInt("pref_oled_textbox_background", DEFAULT_OLED_TEXTBOX_BACKGROUND);
+        Log.d(TAG, String.format("pref_oled_textbox_background: Value=0x%08X, Default=0x%08X", textboxBackgroundColor, DEFAULT_OLED_TEXTBOX_BACKGROUND));
 
+        int textboxAccentColor = prefs.getInt("pref_oled_textbox_accent", DEFAULT_OLED_TEXTBOX_ACCENT);
+        Log.d(TAG, String.format("pref_oled_textbox_accent: Value=0x%08X, Default=0x%08X", textboxAccentColor, DEFAULT_OLED_TEXTBOX_ACCENT));
+
+        int accentGeneralColor = prefs.getInt("pref_oled_accent_general", DEFAULT_OLED_ACCENT_GENERAL);
+        Log.d(TAG, String.format("pref_oled_accent_general: Value=0x%08X, Default=0x%08X", accentGeneralColor, DEFAULT_OLED_ACCENT_GENERAL));
+
+        // Apply colors to Window elements
+        activity.getWindow().setStatusBarColor(mainBackgroundColor);
+        activity.getWindow().setNavigationBarColor(mainBackgroundColor);
+        activity.getWindow().getDecorView().setBackgroundColor(mainBackgroundColor);
+
+        // Apply colors to Toolbar
         Toolbar toolbar = activity.findViewById(R.id.toolbar);
         if (toolbar != null) {
-            Log.d(TAG, "Toolbar found, applying colors.");
-            toolbar.setBackgroundColor(primaryOledColor);
-            toolbar.setTitleTextColor(oledTextColorPrimary);
-            // Potentially set subtitle text color if used: toolbar.setSubtitleTextColor(oledOnPrimaryColor);
-            // Potentially set menu item icon tints if needed, though this is complex here.
+            Log.d(TAG, "Toolbar found, applying new grouped colors.");
+            toolbar.setBackgroundColor(topbarBackgroundColor);
+            toolbar.setTitleTextColor(topbarTextIconColor);
             if (toolbar.getNavigationIcon() != null) {
-                toolbar.getNavigationIcon().setColorFilter(oledOnPrimaryColor, PorterDuff.Mode.SRC_ATOP); // Use onPrimary for nav icon
+                toolbar.getNavigationIcon().setColorFilter(topbarTextIconColor, PorterDuff.Mode.SRC_ATOP);
             }
-            Log.d(TAG, String.format("Toolbar colors applied. New Toolbar BG color: 0x%08X", primaryOledColor));
+            Log.d(TAG, String.format("Toolbar colors applied. BG: 0x%08X, Text/Icon: 0x%08X", topbarBackgroundColor, topbarTextIconColor));
         } else {
             Log.w(TAG, "Toolbar not found (R.id.toolbar). Cannot apply toolbar specific colors.");
         }
-        Log.d(TAG, "Finished applying custom OLED colors.");
+        Log.d(TAG, "Finished applying custom OLED colors via DynamicThemeApplicator.");
     }
 }

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -110,49 +110,59 @@
     <PreferenceCategory android:title="OLED Theme Customizations">
 
         <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_color_primary"
-            android:title="Primary Color"
-            android:summary="Set the primary color for OLED mode" />
+            android:key="pref_oled_topbar_background"
+            android:title="Top Bar Background"
+            android:summary="Background color for Toolbars/AppBars" />
 
         <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_color_on_primary"
-            android:title="On Primary Color"
-            android:summary="Set the text/icon color for elements using Primary Color as background" />
+            android:key="pref_oled_topbar_text_icon"
+            android:title="Top Bar Text &amp; Icons"
+            android:summary="Color for text and icons on Top Bars" />
 
         <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_color_secondary"
-            android:title="Secondary/Accent Color"
-            android:summary="Set the secondary/accent color for OLED mode" />
+            android:key="pref_oled_main_background"
+            android:title="Main Background"
+            android:summary="Main background color for screens, status bar, navigation bar" />
 
         <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_color_background"
-            android:title="Background Color"
-            android:summary="Set the main background color for OLED mode" />
+            android:key="pref_oled_surface_background"
+            android:title="Surface Background"
+            android:summary="Background for elements like cards, dialogs" />
 
         <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_color_surface"
-            android:title="Surface Color"
-            android:summary="Set the surface color for elements like cards, toolbars in OLED mode" />
+            android:key="pref_oled_general_text_primary"
+            android:title="General Primary Text"
+            android:summary="Primary text color on backgrounds/surfaces" />
 
         <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_color_text_primary"
-            android:title="Primary Text Color"
-            android:summary="Set the primary text color for OLED mode" />
+            android:key="pref_oled_general_text_secondary"
+            android:title="General Secondary Text"
+            android:summary="Secondary text color for hints, etc." />
 
         <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_color_text_secondary"
-            android:title="Secondary Text Color"
-            android:summary="Set the secondary text color for OLED mode" />
+            android:key="pref_oled_button_background"
+            android:title="Button Background"
+            android:summary="Background color for main action buttons" />
 
         <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_color_icon_tint"
-            android:title="Icon Tint Color"
-            android:summary="Set the icon tint color for OLED mode" />
+            android:key="pref_oled_button_text_icon"
+            android:title="Button Text &amp; Icons"
+            android:summary="Text and icon color for main action buttons" />
 
         <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_color_edit_text_background"
-            android:title="Text Field Background Color"
-            android:summary="Set the background color for text fields in OLED mode" />
+            android:key="pref_oled_textbox_background"
+            android:title="Text Box Background"
+            android:summary="Background color for text input fields" />
+
+        <com.drgraff.speakkey.settings.ColorPickerPreference
+            android:key="pref_oled_textbox_accent"
+            android:title="Text Box Border/Accent"
+            android:summary="Border or accent color for text input fields" />
+
+        <com.drgraff.speakkey.settings.ColorPickerPreference
+            android:key="pref_oled_accent_general"
+            android:title="General Accent Color"
+            android:summary="Accent color for switches, sliders, other icons" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
This commit refactors the user-configurable OLED color preferences into logically grouped settings with more descriptive names. This enhances usability and clarity for you when customizing the OLED theme.

Key changes:

1.  **SharedPreferences Keys & UI Updated:**
    - Replaced the previous `pref_oled_color_*` keys with new grouped keys (e.g., `pref_oled_topbar_background`, `pref_oled_button_background`, `pref_oled_textbox_background`, `pref_oled_accent_general`, etc.).
    - Updated `root_preferences.xml` with these new keys and more descriptive titles and summaries for each color setting (total of 11 grouped color preferences).
    - Updated default color constants in `DynamicThemeApplicator.java` to align with these new groups.
    - Modified `SettingsActivity.SettingsFragment` to initialize all new `ColorPickerPreference` items with their respective defaults and keys.

2.  **Dynamic Application Logic Updated:**
    - `DynamicThemeApplicator.applyOledColors()` now reads the new grouped preference keys and applies them: - `pref_oled_topbar_background` for Toolbar background. - `pref_oled_topbar_text_icon` for Toolbar title and navigation icon. - `pref_oled_main_background` for Window, Status bar, and Nav bar.
    - `MainActivity.onCreate()` was updated to use the new grouped keys for styling its specific elements:
        - `pref_oled_textbox_background` for EditText backgrounds.
        - `pref_oled_button_background` for action button backgrounds. - `pref_oled_button_text_icon` for action button text.

3.  **Preference Change Listeners Updated:**
    - The `OnSharedPreferenceChangeListener` in both `SettingsActivity` and `MainActivity` were updated with the new list of 11 grouped OLED color keys to ensure UI recreation when any of these settings change.

This refactoring provides a more organized and user-friendly way to customize OLED theme colors for key UI element groups. Preferences for 'Surface Background', 'General Text', 'Textbox Accent', and 'General Accent' are defined and can be picked, but are not yet exhaustively applied to all possible components, focusing first on top bars, main backgrounds, and specific elements in MainActivity.