### PR TITLE
feat: Complete dynamic OLED theming for all specified activities

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/PhotoPromptsActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/PhotoPromptsActivity.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
+import android.content.res.ColorStateList; // Added for ColorStateList
 
 public class PhotoPromptsActivity extends AppCompatActivity
     implements PhotoPromptsAdapter.OnPhotoPromptInteractionListener, SharedPreferences.OnSharedPreferenceChangeListener {
@@ -99,7 +100,39 @@ public class PhotoPromptsActivity extends AppCompatActivity
         String currentActivityThemeValue = this.sharedPreferences.getString(ThemeManager.PREF_KEY_DARK_MODE, ThemeManager.THEME_DEFAULT);
         if (ThemeManager.THEME_OLED.equals(currentActivityThemeValue)) {
             DynamicThemeApplicator.applyOledColors(this, this.sharedPreferences);
-            Log.d(TAG, "PhotoPromptsActivity: Applied dynamic OLED colors.");
+            Log.d(TAG, "PhotoPromptsActivity: Applied dynamic OLED colors for window/toolbar.");
+
+            // Retrieve common button/accent colors
+            int buttonBackgroundColor = this.sharedPreferences.getInt(
+                "pref_oled_button_background",
+                com.drgraff.speakkey.utils.DynamicThemeApplicator.DEFAULT_OLED_BUTTON_BACKGROUND
+            );
+            int buttonTextIconColor = this.sharedPreferences.getInt(
+                "pref_oled_button_text_icon",
+                com.drgraff.speakkey.utils.DynamicThemeApplicator.DEFAULT_OLED_BUTTON_TEXT_ICON
+            );
+            int accentGeneralColor = this.sharedPreferences.getInt(
+                "pref_oled_accent_general",
+                com.drgraff.speakkey.utils.DynamicThemeApplicator.DEFAULT_OLED_ACCENT_GENERAL
+            );
+
+            // Style btnCheckPhotoModels
+            if (btnCheckPhotoModels != null) {
+                btnCheckPhotoModels.setBackgroundTintList(ColorStateList.valueOf(buttonBackgroundColor));
+                btnCheckPhotoModels.setTextColor(buttonTextIconColor);
+                Log.d(TAG, String.format("PhotoPromptsActivity: Styled btnCheckPhotoModels with BG=0x%08X, Text=0x%08X", buttonBackgroundColor, buttonTextIconColor));
+            } else {
+                Log.w(TAG, "PhotoPromptsActivity: btnCheckPhotoModels is null, cannot style.");
+            }
+
+            // Style FloatingActionButton fabAddPhotoPrompt
+            if (fabAddPhotoPrompt != null) {
+                fabAddPhotoPrompt.setBackgroundTintList(ColorStateList.valueOf(accentGeneralColor));
+                fabAddPhotoPrompt.setImageTintList(ColorStateList.valueOf(buttonTextIconColor));
+                Log.d(TAG, String.format("PhotoPromptsActivity: Styled fabAddPhotoPrompt with BG=0x%08X, IconTint=0x%08X", accentGeneralColor, buttonTextIconColor));
+            } else {
+                Log.w(TAG, "PhotoPromptsActivity: fabAddPhotoPrompt is null, cannot style.");
+            }
         }
 
         String apiKey = this.sharedPreferences.getString("openai_api_key", "");


### PR DESCRIPTION
This commit finalizes the rollout of user-configurable OLED theming across all targeted activities within the main application package. It also includes updates for manifest themes of presumed external activities.

Key changes and summary of work:

1.  **Grouped OLED Color Preferences:**
    - Refactored SharedPreferences keys for OLED colors into logical groups (e.g., `pref_oled_topbar_background`, `pref_oled_button_background`).
    - Updated `SettingsActivity` with new `ColorPickerPreference` items for these grouped settings, including descriptive titles/summaries and default values.
    - `DynamicThemeApplicator.java` updated with new default color constants and logic to read/log these new grouped preferences.

2.  **Dynamic Color Application (`DynamicThemeApplicator`):**
    - `DynamicThemeApplicator.applyOledColors()` now uses the new grouped preferences to style: - Toolbar background (`pref_oled_topbar_background`). - Toolbar title text and navigation icon (`pref_oled_topbar_text_icon`). - Window background, Status bar, and Navigation bar (`pref_oled_main_background`).

3.  **Comprehensive Activity Theming:**
    - The following activities were fully integrated into the dynamic theming system, ensuring they respect Light/Dark/OLED modes and custom OLED colors: - `MainActivity` (including Macro buttons, main action buttons, EditTexts) - `PhotosActivity` (including its main action buttons) - `LogActivity` (including its 'Clear Log' button) - `PromptsActivity` (including its 'Check Models' buttons and FAB) - `PromptEditorActivity` (including its save button and EditTexts) - `PhotoPromptEditorActivity` (including its save button and EditTexts) - `FormattingTagsActivity` (including its FAB) - `EditFormattingTagActivity` (including its save button, EditTexts, CheckBoxes) - `AboutActivity` - `SettingsActivity` (serves as the configuration hub)
    - This integration involved:
        - Updating `AndroidManifest.xml` themes to `@style/Theme.SpeakKey`.
        - Implementing standard theme application in `onCreate()` (applying base Light/Dark/OLED themes before `super.onCreate()`). - Calling `DynamicThemeApplicator.applyOledColors()` after `setContentView()` if OLED mode is active. - Implementing state tracking (`mAppliedThemeMode` and relevant `mAppliedOled...Color` variables) populated at the end of `onCreate`. - Implementing `SharedPreferences.OnSharedPreferenceChangeListener` along with `onResume` and `onPause` to manage listener registration and trigger `recreate()` on relevant preference changes. - Styling specific UI elements within each activity using the appropriate grouped OLED color preferences (e.g., buttons using `pref_oled_button_background` and `pref_oled_button_text_icon`, EditTexts using `pref_oled_textbox_background`, FABs using `pref_oled_accent_general`).

4.  **External Activities (Manifest Update Only):**
    - `MacroListActivity` and `MacroEditorActivity` themes in `AndroidManifest.xml` were updated to `@style/Theme.SpeakKey`. Further Java code changes were deemed not feasible due to their likely external library origin.

5.  **Build Error Resolutions:**
    - Addressed various build errors during the process, primarily related to missing constants or imports in `PromptsActivity.java` and `EditFormattingTagActivity.java`, and corrected `DialogInterface` usage in `ColorPickerPreference.java`.

This extensive set of changes provides a significantly more customizable OLED theme experience throughout the application.