### PR TITLE
Fix: Resolve 'cannot find symbol REQUEST_ADD_PROMPT' in PromptsActivity

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/data/PromptsActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/data/PromptsActivity.java
@@ -80,6 +80,7 @@ public class PromptsActivity extends AppCompatActivity
     private static final String TAG = "PromptsActivity"; // Added TAG
     public static final String EXTRA_FILTER_MODE_TYPE = "com.drgraff.speakkey.FILTER_MODE_TYPE";
     private static final int ADD_PROMPT_REQUEST = 1;
+    private static final int REQUEST_ADD_PROMPT = ADD_PROMPT_REQUEST;
     private static final int REQUEST_EDIT_PROMPT = 2;
 
     // Member variables for theme state tracking


### PR DESCRIPTION
This commit addresses a persistent build failure caused by a missing REQUEST_ADD_PROMPT constant in `PromptsActivity.java`.

The following corrections were made in
`app/src/main/java/com/drgraff/speakkey/data/PromptsActivity.java`:

1.  Ensured the constant `ADD_PROMPT_REQUEST` is defined as `private static final int ADD_PROMPT_REQUEST = 1;`.
2.  Added the constant alias `private static final int REQUEST_ADD_PROMPT = ADD_PROMPT_REQUEST;`. This makes `REQUEST_ADD_PROMPT` available for use in `startActivityForResult` calls, resolving the compiler error.
3.  Confirmed the constant `REQUEST_EDIT_PROMPT` and the import for `java.util.Set` are also present.

This targeted fix should ensure the application compiles successfully.