### PR TITLE
Fix: Add missing string resources for macro activity

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -238,4 +238,6 @@ SpeakKey streamlines data entry, coding, writing, and any task involving text in
     <string name="empty_prompts_two_step_text">No Two Step prompts. Click \'+\' to add.</string>
     <string name="empty_prompts_photo_text">No Photo prompts. Click \'+\' to add.</string>
 
+    <string name="no_macros_message">No macros found. Tap the \'+\' button to create one.</string>
+    <string name="add_macro_content_description">Add new macro</string>
 </resources>


### PR DESCRIPTION
This commit resolves a build failure caused by missing string resources (`no_macros_message` and `add_macro_content_description`) referenced in `layout/activity_macros.xml`.

The following string resources were added to
`app/src/main/res/values/strings.xml`:

- `no_macros_message`: "No macros found. Tap the '+' button to create one."
- `add_macro_content_description`: "Add new macro"

This ensures that the layout file can correctly link these resources, allowing the application to build successfully.