### PR TITLE
Fix: Resolve 'cannot find symbol' in PhotosActivity

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
@@ -598,7 +598,7 @@ public class PhotosActivity extends AppCompatActivity implements FullScreenEditT
                 if (photoFile.exists() && photoFile.length() == 0) photoFile.delete();
             }
         } else if ((requestCode == REQUEST_ADD_PHOTO_PROMPT || requestCode == REQUEST_EDIT_PHOTO_PROMPT) && resultCode == Activity.RESULT_OK) {
-             if (photoPromptsAdapter != null) loadPhotoPrompts();
+             if (photoPromptsAdapter != null) updateActivePhotoPromptsDisplay();
         }
     }
 


### PR DESCRIPTION
The onActivityResult method in PhotosActivity.java was attempting to call a non-existent method `loadPhotoPrompts()`. This caused a compilation error.

This commit fixes the issue by changing the call to `updateActivePhotoPromptsDisplay()`, which is an existing method in PhotosActivity responsible for refreshing the display of active photo prompts. This is the correct behavior when returning from an activity that might have modified these prompts.

The build verification was not fully completed in my automated environment due to the absence of a configured Android SDK. The fix addresses the specific 'cannot find symbol' error.