### PR TITLE
Fix: Apply OLED theming to FAB and Switches in FormattingTagsActivity

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTagAdapter.java
+++ b/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTagAdapter.java
@@ -9,6 +9,12 @@ import android.view.ViewGroup;
 import android.widget.ImageButton;
 import android.widget.TextView;
 import android.widget.Toast;
+import android.content.SharedPreferences;
+import android.content.res.ColorStateList;
+import androidx.core.graphics.ColorUtils;
+import androidx.preference.PreferenceManager;
+import com.drgraff.speakkey.utils.DynamicThemeApplicator;
+import com.drgraff.speakkey.utils.ThemeManager;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.recyclerview.widget.RecyclerView;
@@ -47,6 +53,43 @@ public class FormattingTagAdapter extends RecyclerView.Adapter<FormattingTagAdap
         holder.tagKeystrokesTextView.setText(currentTag.getKeystrokeSequence());
         // Set the delay text
         holder.textTagDelayMs.setText(String.valueOf(currentTag.getDelayMs()) + " ms");
+
+        // OLED Theming for SwitchCompat
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        String currentTheme = prefs.getString(ThemeManager.PREF_KEY_DARK_MODE, ThemeManager.THEME_DEFAULT);
+
+        if (ThemeManager.THEME_OLED.equals(currentTheme)) {
+            int accentColor = prefs.getInt("pref_oled_accent_general", DynamicThemeApplicator.DEFAULT_OLED_ACCENT_GENERAL);
+            int secondaryTextColor = prefs.getInt("pref_oled_general_text_secondary", DynamicThemeApplicator.DEFAULT_OLED_GENERAL_TEXT_SECONDARY);
+            int primaryTextColor = prefs.getInt("pref_oled_general_text_primary", DynamicThemeApplicator.DEFAULT_OLED_GENERAL_TEXT_PRIMARY);
+
+            ColorStateList thumbTintList = new ColorStateList(
+                new int[][]{
+                    new int[]{android.R.attr.state_checked},
+                    new int[]{-android.R.attr.state_checked}
+                },
+                new int[]{
+                    accentColor,        // Checked
+                    primaryTextColor    // Unchecked
+                }
+            );
+
+            ColorStateList trackTintList = new ColorStateList(
+                new int[][]{
+                    new int[]{android.R.attr.state_checked},
+                    new int[]{-android.R.attr.state_checked}
+                },
+                new int[]{
+                    ColorUtils.setAlphaComponent(accentColor, 128),        // Checked (50% alpha)
+                    ColorUtils.setAlphaComponent(secondaryTextColor, 128) // Unchecked (50% alpha)
+                }
+            );
+
+            holder.tagActiveSwitch.setThumbTintList(thumbTintList);
+            holder.tagActiveSwitch.setTrackTintList(trackTintList);
+        }
+
+        // Set checked state AFTER applying tints, if any, and before setting listener
         holder.tagActiveSwitch.setChecked(currentTag.isActive());
 
         // Remove previous listeners to prevent multiple triggers

--- a/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTagsActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/formattingtags/FormattingTagsActivity.java
@@ -64,6 +64,11 @@ public class FormattingTagsActivity extends AppCompatActivity implements SharedP
             getSupportActionBar().setTitle(getString(R.string.formatting_tags_activity_title));
         }
 
+        // Initialize UI elements FIRST
+        recyclerView = findViewById(R.id.formatting_tags_recycler_view);
+        emptyView = findViewById(R.id.empty_formatting_tags_text_view);
+        fabAddTag = findViewById(R.id.fab_add_formatting_tag);
+
         String currentActivityThemeValue = this.sharedPreferences.getString(ThemeManager.PREF_KEY_DARK_MODE, ThemeManager.THEME_DEFAULT);
         if (ThemeManager.THEME_OLED.equals(currentActivityThemeValue)) {
             DynamicThemeApplicator.applyOledColors(this, this.sharedPreferences);
@@ -88,10 +93,6 @@ public class FormattingTagsActivity extends AppCompatActivity implements SharedP
                 Log.w(TAG, "FormattingTagsActivity: fabAddTag is null, cannot style.");
             }
         }
-
-        recyclerView = findViewById(R.id.formatting_tags_recycler_view);
-        emptyView = findViewById(R.id.empty_formatting_tags_text_view);
-        fabAddTag = findViewById(R.id.fab_add_formatting_tag);
 
         tagManager = new FormattingTagManager(this);
 


### PR DESCRIPTION
This commit ensures that the FloatingActionButton (FAB) and the activation Switches in the FormattingTagsActivity and its adapter (`FormattingTagsActivity.java`, `FormattingTagAdapter.java`) correctly follow your OLED theme settings.

Changes:
1.  **FormattingTagsActivity.java - FAB Theming**:
    *   Corrected an issue where `fabAddTag` was styled programmatically before its `findViewById` initialization.
    *   Moved the `findViewById` calls for UI elements to occur *before* the OLED styling block, allowing the existing FAB theming logic (using `pref_oled_accent_general` and `pref_oled_button_text_icon`) to function correctly.

2.  **FormattingTagAdapter.java - Switch Theming**:
    *   Modified the `onBindViewHolder` method.
    *   When the OLED theme is active, SwitchCompat elements (`tag_active_switch`) are now programmatically tinted.
    *   Thumb colors: `pref_oled_accent_general` (checked), `pref_oled_general_text_primary` (unchecked).
    *   Track colors: 50% alpha of `pref_oled_accent_general` (checked), 50% alpha of `pref_oled_general_text_secondary` (unchecked).
    *   This ensures that these switches visually conform to the selected OLED theme colors.