### PR TITLE
Here's the proposed change:

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/formattingtags/EditFormattingTagActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/formattingtags/EditFormattingTagActivity.java
@@ -91,6 +91,17 @@ public class EditFormattingTagActivity extends AppCompatActivity implements Shar
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
 
+        // Initialize UI elements FIRST
+        editTextName = findViewById(R.id.edit_tag_name);
+        editTextOpeningTag = findViewById(R.id.edit_tag_opening_text);
+        editTextTagDelayMs = findViewById(R.id.editTextTagDelayMs);
+        checkBoxCtrl = findViewById(R.id.checkbox_modifier_ctrl);
+        checkBoxAlt = findViewById(R.id.checkbox_modifier_alt);
+        checkBoxShift = findViewById(R.id.checkbox_modifier_shift);
+        checkBoxMeta = findViewById(R.id.checkbox_modifier_meta);
+        spinnerMainKey = findViewById(R.id.spinner_main_key);
+        buttonSave = findViewById(R.id.button_save_formatting_tag);
+
         String currentActivityThemeValue = this.sharedPreferences.getString(ThemeManager.PREF_KEY_DARK_MODE, ThemeManager.THEME_DEFAULT);
         if (ThemeManager.THEME_OLED.equals(currentActivityThemeValue)) {
             DynamicThemeApplicator.applyOledColors(this, this.sharedPreferences);
@@ -154,16 +165,6 @@ public class EditFormattingTagActivity extends AppCompatActivity implements Shar
                 }
             }
         }
-
-        editTextName = findViewById(R.id.edit_tag_name);
-        editTextOpeningTag = findViewById(R.id.edit_tag_opening_text);
-        editTextTagDelayMs = findViewById(R.id.editTextTagDelayMs);
-        checkBoxCtrl = findViewById(R.id.checkbox_modifier_ctrl);
-        checkBoxAlt = findViewById(R.id.checkbox_modifier_alt);
-        checkBoxShift = findViewById(R.id.checkbox_modifier_shift);
-        checkBoxMeta = findViewById(R.id.checkbox_modifier_meta);
-        spinnerMainKey = findViewById(R.id.spinner_main_key);
-        buttonSave = findViewById(R.id.button_save_formatting_tag);
 
         populateMainKeySpinner();
 

--- a/app/src/main/res/layout/activity_edit_formatting_tag.xml
+++ b/app/src/main/res/layout/activity_edit_formatting_tag.xml
@@ -127,9 +127,7 @@
             android:layout_marginTop="24dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/save_button_text"
-            android:backgroundTint="?attr/colorPrimary"
-            android:textColor="?attr/colorOnPrimary"/>
+            android:text="@string/save_button_text"/>
 
     </LinearLayout>
 


### PR DESCRIPTION
Fix: Apply OLED theming to EditFormattingTagActivity

This commit ensures that UI elements (Buttons, EditTexts, CheckBoxes) in `EditFormattingTagActivity.java` correctly follow your OLED theme settings.

Changes:
1.  **EditFormattingTagActivity.java**:
    *   Corrected an issue where UI elements were styled programmatically before they were properly initialized.
    *   Moved the initialization of all relevant UI elements (`buttonSave`, `editTextName`, `editTextOpeningTag`, `editTextTagDelayMs`, and checkboxes) to occur *before* the conditional block that applies OLED theme styling.
    *   This allows the existing styling logic for these elements (using `pref_oled_button_background`, `pref_oled_button_text_icon`, `pref_oled_textbox_background`, and `pref_oled_accent_general`) to function correctly.

2.  **activity_edit_formatting_tag.xml**:
    *   Removed hardcoded `android:backgroundTint` and `android:textColor` attributes from the `button_save_formatting_tag`. This allows its appearance to be fully controlled by the programmatic OLED theming.