### PR TITLE
Fix: Apply OLED theming to LogActivity and LogAdapter

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/utils/LogActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/utils/LogActivity.java
@@ -28,6 +28,8 @@ public class LogActivity extends AppCompatActivity implements SharedPreferences.
     private int mAppliedTopbarBackgroundColor = 0;
     private int mAppliedTopbarTextIconColor = 0;
     private int mAppliedMainBackgroundColor = 0;
+    private int mAppliedOledButtonBackgroundColor = 0;
+    private int mAppliedOledButtonTextIconColor = 0;
     private static final String TAG = "LogActivity";
 
     @Override
@@ -53,6 +55,10 @@ public class LogActivity extends AppCompatActivity implements SharedPreferences.
             actionBar.setDisplayHomeAsUpEnabled(true);
             actionBar.setTitle("Application Log");
         }
+
+        // Initialize UI elements that need styling BEFORE the theme block
+        logRecyclerView = findViewById(R.id.log_recycler_view);
+        clearLogButton = findViewById(R.id.clear_log_button); // Now initialized
 
         // Apply custom OLED colors if OLED theme is active
         // Re-fetch currentThemeValue as themeValue was for pre-super.onCreate
@@ -81,9 +87,6 @@ public class LogActivity extends AppCompatActivity implements SharedPreferences.
             }
         }
 
-        logRecyclerView = findViewById(R.id.log_recycler_view);
-        clearLogButton = findViewById(R.id.clear_log_button);
-
         logRecyclerView.setLayoutManager(new LinearLayoutManager(this));
         logAdapter = new LogAdapter(new ArrayList<>()); 
         logRecyclerView.setAdapter(logAdapter);
@@ -100,14 +103,19 @@ public class LogActivity extends AppCompatActivity implements SharedPreferences.
             this.mAppliedTopbarBackgroundColor = this.sharedPreferences.getInt("pref_oled_topbar_background", DynamicThemeApplicator.DEFAULT_OLED_TOPBAR_BACKGROUND);
             this.mAppliedTopbarTextIconColor = this.sharedPreferences.getInt("pref_oled_topbar_text_icon", DynamicThemeApplicator.DEFAULT_OLED_TOPBAR_TEXT_ICON);
             this.mAppliedMainBackgroundColor = this.sharedPreferences.getInt("pref_oled_main_background", DynamicThemeApplicator.DEFAULT_OLED_MAIN_BACKGROUND);
+            this.mAppliedOledButtonBackgroundColor = this.sharedPreferences.getInt("pref_oled_button_background", DynamicThemeApplicator.DEFAULT_OLED_BUTTON_BACKGROUND);
+            this.mAppliedOledButtonTextIconColor = this.sharedPreferences.getInt("pref_oled_button_text_icon", DynamicThemeApplicator.DEFAULT_OLED_BUTTON_TEXT_ICON);
             Log.d(TAG, "LogActivity onCreate: Stored mAppliedThemeMode=" + mAppliedThemeMode +
                          ", TopbarBG=0x" + Integer.toHexString(mAppliedTopbarBackgroundColor) +
                          ", TopbarTextIcon=0x" + Integer.toHexString(mAppliedTopbarTextIconColor) +
                          ", MainBG=0x" + Integer.toHexString(mAppliedMainBackgroundColor));
+            Log.d(TAG, "LogActivity onCreate: Stored specific OLED colors: ButtonBG=0x" + Integer.toHexString(mAppliedOledButtonBackgroundColor) + ", ButtonTextIcon=0x" + Integer.toHexString(mAppliedOledButtonTextIconColor));
         } else {
             this.mAppliedTopbarBackgroundColor = 0;
             this.mAppliedTopbarTextIconColor = 0;
             this.mAppliedMainBackgroundColor = 0;
+            this.mAppliedOledButtonBackgroundColor = 0;
+            this.mAppliedOledButtonTextIconColor = 0;
             Log.d(TAG, "LogActivity onCreate: Stored mAppliedThemeMode=" + mAppliedThemeMode + ". Not OLED mode, OLED colors reset.");
         }
     }
@@ -132,6 +140,18 @@ public class LogActivity extends AppCompatActivity implements SharedPreferences.
 
                 int currentMainBG = this.sharedPreferences.getInt("pref_oled_main_background", DynamicThemeApplicator.DEFAULT_OLED_MAIN_BACKGROUND);
                 if (mAppliedMainBackgroundColor != currentMainBG) needsRecreate = true;
+
+                int currentOledButtonBg = sharedPreferences.getInt("pref_oled_button_background", DynamicThemeApplicator.DEFAULT_OLED_BUTTON_BACKGROUND);
+                if (mAppliedOledButtonBackgroundColor != currentOledButtonBg) {
+                    needsRecreate = true;
+                    Log.d(TAG, "onResume: OLED Button Background Color changed in LogActivity. Old=0x" + Integer.toHexString(mAppliedOledButtonBackgroundColor) + ", New=0x" + Integer.toHexString(currentOledButtonBg));
+                }
+
+                int currentOledButtonTextIcon = sharedPreferences.getInt("pref_oled_button_text_icon", DynamicThemeApplicator.DEFAULT_OLED_BUTTON_TEXT_ICON);
+                if (mAppliedOledButtonTextIconColor != currentOledButtonTextIcon) {
+                    needsRecreate = true;
+                    Log.d(TAG, "onResume: OLED Button Text/Icon Color changed in LogActivity. Old=0x" + Integer.toHexString(mAppliedOledButtonTextIconColor) + ", New=0x" + Integer.toHexString(currentOledButtonTextIcon));
+                }
 
                 if (needsRecreate) {
                      Log.d(TAG, "onResume: OLED color(s) changed for LogActivity.");

--- a/app/src/main/java/com/drgraff/speakkey/utils/LogAdapter.java
+++ b/app/src/main/java/com/drgraff/speakkey/utils/LogAdapter.java
@@ -5,6 +5,11 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
+import android.content.SharedPreferences;
+import androidx.preference.PreferenceManager;
+import com.drgraff.speakkey.utils.ThemeManager;
+import com.drgraff.speakkey.utils.DynamicThemeApplicator;
+import androidx.core.content.ContextCompat; // For potential fallback colors
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
@@ -44,20 +49,63 @@ public class LogAdapter extends RecyclerView.Adapter<LogAdapter.LogViewHolder> {
             holder.detailTextView.setVisibility(View.GONE);
         }
 
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(holder.itemView.getContext());
+        String currentTheme = prefs.getString(ThemeManager.PREF_KEY_DARK_MODE, ThemeManager.THEME_DEFAULT);
+        boolean isOledMode = ThemeManager.THEME_OLED.equals(currentTheme);
+
+        int oledPrimaryTextColor = 0;
+        int oledSecondaryTextColor = 0;
+        if (isOledMode) {
+            oledPrimaryTextColor = prefs.getInt("pref_oled_general_text_primary", DynamicThemeApplicator.DEFAULT_OLED_GENERAL_TEXT_PRIMARY);
+            oledSecondaryTextColor = prefs.getInt("pref_oled_general_text_secondary", DynamicThemeApplicator.DEFAULT_OLED_GENERAL_TEXT_SECONDARY);
+
+            holder.timestampTextView.setTextColor(oledSecondaryTextColor);
+            holder.messageTextView.setTextColor(oledPrimaryTextColor);
+            holder.detailTextView.setTextColor(oledPrimaryTextColor); // Or secondary if preferred
+        } else {
+            // Optional: Explicitly set to default theme colors if not OLED.
+            // This example assumes TextViews will inherit appropriate colors from the base theme.
+            // If specific default colors are needed, they can be set here using ContextCompat.getColor.
+            // For instance:
+            // holder.timestampTextView.setTextColor(ContextCompat.getColor(holder.itemView.getContext(), R.color.default_log_timestamp_color));
+            // holder.messageTextView.setTextColor(ContextCompat.getColor(holder.itemView.getContext(), R.color.default_log_message_color));
+            // holder.detailTextView.setTextColor(ContextCompat.getColor(holder.itemView.getContext(), R.color.default_log_detail_color));
+            // For now, we rely on base theme inheritance for non-OLED.
+        }
+
         // Set color based on log level
-        switch (entry.level.toUpperCase()) {
-            case "ERROR":
-                holder.levelTextView.setTextColor(Color.RED);
-                break;
-            case "SUCCESS":
-                holder.levelTextView.setTextColor(Color.parseColor("#006400")); // Dark Green
-                break;
-            case "INFO":
-                holder.levelTextView.setTextColor(Color.BLUE);
-                break;
-            default:
-                holder.levelTextView.setTextColor(Color.BLACK);
-                break;
+        if (isOledMode) {
+            switch (entry.level.toUpperCase()) {
+                case "ERROR":
+                    holder.levelTextView.setTextColor(Color.parseColor("#FF5252")); // Brighter Red for OLED
+                    break;
+                case "SUCCESS":
+                    holder.levelTextView.setTextColor(Color.parseColor("#69F0AE")); // Brighter Green for OLED
+                    break;
+                case "INFO":
+                    int infoColor = prefs.getInt("pref_oled_accent_general", DynamicThemeApplicator.DEFAULT_OLED_ACCENT_GENERAL);
+                    holder.levelTextView.setTextColor(infoColor);
+                    break;
+                default: // WARN, DEBUG, etc.
+                    holder.levelTextView.setTextColor(oledPrimaryTextColor); // Default to primary OLED text color
+                    break;
+            }
+        } else {
+            // Existing non-OLED color logic
+            switch (entry.level.toUpperCase()) {
+                case "ERROR":
+                    holder.levelTextView.setTextColor(Color.RED);
+                    break;
+                case "SUCCESS":
+                    holder.levelTextView.setTextColor(Color.parseColor("#006400")); // Dark Green
+                    break;
+                case "INFO":
+                    holder.levelTextView.setTextColor(Color.BLUE);
+                    break;
+                default: // WARN, DEBUG, etc.
+                    holder.levelTextView.setTextColor(Color.BLACK);
+                    break;
+            }
         }
     }
 


### PR DESCRIPTION
This commit ensures that LogActivity and its log entries (via LogAdapter) correctly follow OLED theme settings and update dynamically.

Changes:
1.  **LogActivity.java**:
    *   Corrected an issue where the 'Clear Logs' button (`clearLogButton`) was styled programmatically before its `findViewById` initialization. Moved `findViewById` calls to occur *before* OLED styling logic in `onCreate`.
    *   Enhanced dynamic theme update handling:
        *   Added member variables (`mAppliedOledButtonBackgroundColor`, `mAppliedOledButtonTextIconColor`) to store specific OLED colors for the 'Clear Logs' button.
        *   Updated `onCreate` to populate these variables when OLED theme is active and reset them otherwise.
        *   Updated `onResume` to check these button-specific colors against current preferences. If a mismatch is detected while OLED theme is active, `recreate()` is called.

2.  **LogAdapter.java**:
    *   Modified `onBindViewHolder` to be theme-aware.
    *   When OLED theme is active:
        *   Timestamp, message, and detail TextViews now use `pref_oled_general_text_primary` or `pref_oled_general_text_secondary`.
        *   Log level TextViews use brighter, OLED-friendly static colors (e.g., `#FF5252` for ERROR) or `pref_oled_accent_general` (for INFO).
    *   Original color logic for log levels is preserved for non-OLED themes.

This ensures that the log viewing screen and its contents are visually consistent with the selected OLED theme and respond to dynamic theme changes.