### PR TITLE
Refactor: Move OLED Theme Customizations to a dedicated screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,6 +57,14 @@
             android:label="@string/title_activity_settings"
             android:parentActivityName=".MainActivity" />
         <activity
+            android:name="com.drgraff.speakkey.settings.OledThemeSettingsActivity"
+            android:label="OLED Theme Settings"
+            android:parentActivityName="com.drgraff.speakkey.settings.SettingsActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.drgraff.speakkey.settings.SettingsActivity" />
+        </activity>
+        <activity
             android:name=".ui.AboutActivity"
             android:label="@string/about_activity_title"
             android:parentActivityName=".MainActivity"

--- a/app/src/main/java/com/drgraff/speakkey/settings/OledThemeSettingsActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/settings/OledThemeSettingsActivity.java
@@ -1,0 +1,165 @@
+package com.drgraff.speakkey.settings;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.MenuItem;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.preference.PreferenceManager;
+import com.drgraff.speakkey.R;
+import com.drgraff.speakkey.utils.DynamicThemeApplicator;
+import com.drgraff.speakkey.utils.ThemeManager;
+
+public class OledThemeSettingsActivity extends AppCompatActivity implements SharedPreferences.OnSharedPreferenceChangeListener {
+
+    private static final String TAG = "OledSettingsActivity";
+    private SharedPreferences sharedPreferences;
+
+    // Member variables for theme state tracking
+    private String mAppliedThemeMode = null;
+    private int mAppliedTopbarBackgroundColor = 0;
+    private int mAppliedTopbarTextIconColor = 0;
+    private int mAppliedMainBackgroundColor = 0;
+    // Add any other specific colors this activity might directly style or need to track for recreate
+    // For a settings screen, usually the main/topbar/surface colors are most relevant for the activity frame.
+    // The PreferenceFragment itself will handle its item text colors based on the theme.
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+
+        ThemeManager.applyTheme(sharedPreferences);
+        String themeValue = sharedPreferences.getString(ThemeManager.PREF_KEY_DARK_MODE, ThemeManager.THEME_DEFAULT);
+        if (ThemeManager.THEME_OLED.equals(themeValue)) {
+            setTheme(R.style.AppTheme_OLED);
+        }
+
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_oled_theme_settings);
+
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true);
+            actionBar.setTitle("OLED Theme Customizations"); // Or use a string resource
+        }
+
+        // Apply dynamic OLED colors for toolbar and window background if OLED theme is active
+        String currentActivityThemeValue = sharedPreferences.getString(ThemeManager.PREF_KEY_DARK_MODE, ThemeManager.THEME_DEFAULT);
+        if (ThemeManager.THEME_OLED.equals(currentActivityThemeValue)) {
+            DynamicThemeApplicator.applyOledColors(this, sharedPreferences);
+            Log.d(TAG, "OledThemeSettingsActivity: Applied dynamic OLED colors for window/toolbar.");
+        }
+
+        if (savedInstanceState == null) {
+            getSupportFragmentManager()
+                    .beginTransaction()
+                    .replace(R.id.settings_container, new OledThemeSettingsFragment())
+                    .commit();
+        }
+
+        // Store applied theme state for dynamic updates
+        this.mAppliedThemeMode = currentActivityThemeValue;
+        if (ThemeManager.THEME_OLED.equals(currentActivityThemeValue)) {
+            this.mAppliedTopbarBackgroundColor = sharedPreferences.getInt("pref_oled_topbar_background", DynamicThemeApplicator.DEFAULT_OLED_TOPBAR_BACKGROUND);
+            this.mAppliedTopbarTextIconColor = sharedPreferences.getInt("pref_oled_topbar_text_icon", DynamicThemeApplicator.DEFAULT_OLED_TOPBAR_TEXT_ICON);
+            this.mAppliedMainBackgroundColor = sharedPreferences.getInt("pref_oled_main_background", DynamicThemeApplicator.DEFAULT_OLED_MAIN_BACKGROUND);
+            Log.d(TAG, "OledThemeSettingsActivity onCreate: Stored mAppliedThemeMode=" + mAppliedThemeMode +
+                         ", TopbarBG=0x" + Integer.toHexString(mAppliedTopbarBackgroundColor) +
+                         ", TopbarTextIcon=0x" + Integer.toHexString(mAppliedTopbarTextIconColor) +
+                         ", MainBG=0x" + Integer.toHexString(mAppliedMainBackgroundColor));
+        } else {
+            this.mAppliedTopbarBackgroundColor = 0;
+            this.mAppliedTopbarTextIconColor = 0;
+            this.mAppliedMainBackgroundColor = 0;
+            Log.d(TAG, "OledThemeSettingsActivity onCreate: Stored mAppliedThemeMode=" + mAppliedThemeMode + ". Not OLED mode.");
+        }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        // Register listener first
+        sharedPreferences.registerOnSharedPreferenceChangeListener(this);
+
+        // Then check if recreate is needed
+        if (mAppliedThemeMode != null) {
+            boolean needsRecreate = false;
+            String currentThemeValue = sharedPreferences.getString(ThemeManager.PREF_KEY_DARK_MODE, ThemeManager.THEME_DEFAULT);
+
+            if (!mAppliedThemeMode.equals(currentThemeValue)) {
+                needsRecreate = true;
+                Log.d(TAG, "onResume: Theme mode changed. OldMode=" + mAppliedThemeMode + ", NewMode=" + currentThemeValue);
+            } else if (ThemeManager.THEME_OLED.equals(currentThemeValue)) {
+                // Check specific OLED colors relevant to this activity's frame/toolbar
+                if (mAppliedTopbarBackgroundColor != sharedPreferences.getInt("pref_oled_topbar_background", DynamicThemeApplicator.DEFAULT_OLED_TOPBAR_BACKGROUND)) needsRecreate = true;
+                if (mAppliedTopbarTextIconColor != sharedPreferences.getInt("pref_oled_topbar_text_icon", DynamicThemeApplicator.DEFAULT_OLED_TOPBAR_TEXT_ICON)) needsRecreate = true;
+                if (mAppliedMainBackgroundColor != sharedPreferences.getInt("pref_oled_main_background", DynamicThemeApplicator.DEFAULT_OLED_MAIN_BACKGROUND)) needsRecreate = true;
+
+                // Add more checks here if this activity directly styles other elements with specific OLED prefs
+                // For now, assuming the main/topbar/surface are primary concerns for the Activity frame.
+                // The PreferenceFragment itself should update its items if the theme causes general text color changes.
+            }
+
+            if (needsRecreate) {
+                Log.d(TAG, "onResume: Detected configuration change. Recreating OledThemeSettingsActivity.");
+                recreate();
+                // No return needed here as recreate() itself will restart the activity.
+                // The listener will be re-registered in the new instance's onResume.
+            }
+        }
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        sharedPreferences.unregisterOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        Log.d(TAG, "onSharedPreferenceChanged triggered for key: " + key);
+        if (key == null) return;
+
+        final String[] oledColorKeys = {
+            "pref_oled_topbar_background", "pref_oled_topbar_text_icon",
+            "pref_oled_main_background", "pref_oled_surface_background",
+            "pref_oled_general_text_primary", "pref_oled_general_text_secondary",
+            "pref_oled_button_background", "pref_oled_button_text_icon",
+            "pref_oled_textbox_background", "pref_oled_textbox_accent",
+            "pref_oled_accent_general"
+            // Add any new specific keys if this activity were to style more elements directly
+        };
+        boolean isOledColorKey = false;
+        for (String oledKey : oledColorKeys) {
+            if (oledKey.equals(key)) {
+                isOledColorKey = true;
+                break;
+            }
+        }
+
+        if (ThemeManager.PREF_KEY_DARK_MODE.equals(key)) {
+            Log.d(TAG, "Main theme preference changed. Recreating OledThemeSettingsActivity.");
+            recreate();
+        } else if (isOledColorKey) {
+            String currentTheme = sharedPreferences.getString(ThemeManager.PREF_KEY_DARK_MODE, ThemeManager.THEME_DEFAULT);
+            if (ThemeManager.THEME_OLED.equals(currentTheme)) {
+                Log.d(TAG, "OLED color preference changed: " + key + ". Recreating OledThemeSettingsActivity.");
+                recreate();
+            }
+        }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish(); // Or NavUtils.navigateUpFromSameTask(this); if parent is set in manifest
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+}

--- a/app/src/main/java/com/drgraff/speakkey/settings/OledThemeSettingsFragment.java
+++ b/app/src/main/java/com/drgraff/speakkey/settings/OledThemeSettingsFragment.java
@@ -1,0 +1,14 @@
+package com.drgraff.speakkey.settings;
+
+import android.os.Bundle;
+import androidx.annotation.Nullable;
+import androidx.preference.PreferenceFragmentCompat;
+import com.drgraff.speakkey.R;
+
+public class OledThemeSettingsFragment extends PreferenceFragmentCompat {
+
+    @Override
+    public void onCreatePreferences(@Nullable Bundle savedInstanceState, @Nullable String rootKey) {
+        setPreferencesFromResource(R.xml.oled_theme_preferences, rootKey);
+    }
+}

--- a/app/src/main/java/com/drgraff/speakkey/settings/SettingsActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/settings/SettingsActivity.java
@@ -1,8 +1,9 @@
 package com.drgraff.speakkey.settings;
 
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.app.ProgressDialog;
-import android.content.SharedPreferences;
+// import android.content.SharedPreferences; // Duplicate
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -177,6 +178,17 @@ public class SettingsActivity extends AppCompatActivity {
             ListPreference twoStepStep1EnginePrefOnCreate = findPreference(SettingsActivity.PREF_KEY_TWOSTEP_STEP1_ENGINE);
             if (twoStepStep1EnginePrefOnCreate != null) {
                 updateTwoStepStep1ModelVisibility(twoStepStep1EnginePrefOnCreate.getValue());
+            }
+
+            Preference oledSettingsScreenPreference = findPreference("pref_oled_theme_settings_screen");
+            if (oledSettingsScreenPreference != null) {
+                oledSettingsScreenPreference.setOnPreferenceClickListener(preference -> {
+                    if (getActivity() != null) {
+                        Intent intent = new Intent(getActivity(), OledThemeSettingsActivity.class);
+                        startActivity(intent);
+                    }
+                    return true; // Indicates the click was handled
+                });
             }
         }
 

--- a/app/src/main/res/layout/activity_oled_theme_settings.xml
+++ b/app/src/main/res/layout/activity_oled_theme_settings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".settings.OledThemeSettingsActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/Theme.SpeakKey.AppBarOverlay">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/Theme.SpeakKey.PopupOverlay" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <FrameLayout
+        android:id="@+id/settings_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</LinearLayout>

--- a/app/src/main/res/xml/oled_theme_preferences.xml
+++ b/app/src/main/res/xml/oled_theme_preferences.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <PreferenceCategory android:title="OLED Theme Customizations">
+
+        <com.drgraff.speakkey.settings.ColorPickerPreference
+            android:key="pref_oled_topbar_background"
+            android:title="Top Bar Background"
+            android:summary="Background color for Toolbars/AppBars" />
+
+        <com.drgraff.speakkey.settings.ColorPickerPreference
+            android:key="pref_oled_topbar_text_icon"
+            android:title="Top Bar Text &amp; Icons"
+            android:summary="Color for text and icons on Top Bars" />
+
+        <com.drgraff.speakkey.settings.ColorPickerPreference
+            android:key="pref_oled_main_background"
+            android:title="Main Background"
+            android:summary="Main background color for screens, status bar, navigation bar" />
+
+        <com.drgraff.speakkey.settings.ColorPickerPreference
+            android:key="pref_oled_surface_background"
+            android:title="Surface Background"
+            android:summary="Background for elements like cards, dialogs" />
+
+        <com.drgraff.speakkey.settings.ColorPickerPreference
+            android:key="pref_oled_general_text_primary"
+            android:title="General Primary Text"
+            android:summary="Primary text color on backgrounds/surfaces" />
+
+        <com.drgraff.speakkey.settings.ColorPickerPreference
+            android:key="pref_oled_general_text_secondary"
+            android:title="General Secondary Text"
+            android:summary="Secondary text color for hints, etc." />
+
+        <com.drgraff.speakkey.settings.ColorPickerPreference
+            android:key="pref_oled_button_background"
+            android:title="Button Background"
+            android:summary="Background color for main action buttons" />
+
+        <com.drgraff.speakkey.settings.ColorPickerPreference
+            android:key="pref_oled_button_text_icon"
+            android:title="Button Text &amp; Icons"
+            android:summary="Text and icon color for main action buttons" />
+
+        <com.drgraff.speakkey.settings.ColorPickerPreference
+            android:key="pref_oled_textbox_background"
+            android:title="Text Box Background"
+            android:summary="Background color for text input fields" />
+
+        <com.drgraff.speakkey.settings.ColorPickerPreference
+            android:key="pref_oled_textbox_accent"
+            android:title="Text Box Border/Accent"
+            android:summary="Border or accent color for text input fields" />
+
+        <com.drgraff.speakkey.settings.ColorPickerPreference
+            android:key="pref_oled_accent_general"
+            android:title="General Accent Color"
+            android:summary="Accent color for switches, sliders, other icons" />
+
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -94,6 +94,11 @@
             android:entryValues="@array/dark_mode_values"
             android:defaultValue="default" />
 
+        <Preference
+            android:key="pref_oled_theme_settings_screen"
+            android:title="OLED Theme Customizations"
+            android:summary="Configure colors for the OLED theme" />
+
         <SwitchPreferenceCompat
             android:key="auto_send_whisper"
             android:title="@string/settings_auto_send_whisper_title"
@@ -105,65 +110,6 @@
             android:title="@string/settings_auto_send_inputstick_title"
             android:summary="@string/settings_auto_send_inputstick_summary"
             android:defaultValue="false" />
-    </PreferenceCategory>
-
-    <PreferenceCategory android:title="OLED Theme Customizations">
-
-        <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_topbar_background"
-            android:title="Top Bar Background"
-            android:summary="Background color for Toolbars/AppBars" />
-
-        <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_topbar_text_icon"
-            android:title="Top Bar Text &amp; Icons"
-            android:summary="Color for text and icons on Top Bars" />
-
-        <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_main_background"
-            android:title="Main Background"
-            android:summary="Main background color for screens, status bar, navigation bar" />
-
-        <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_surface_background"
-            android:title="Surface Background"
-            android:summary="Background for elements like cards, dialogs" />
-
-        <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_general_text_primary"
-            android:title="General Primary Text"
-            android:summary="Primary text color on backgrounds/surfaces" />
-
-        <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_general_text_secondary"
-            android:title="General Secondary Text"
-            android:summary="Secondary text color for hints, etc." />
-
-        <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_button_background"
-            android:title="Button Background"
-            android:summary="Background color for main action buttons" />
-
-        <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_button_text_icon"
-            android:title="Button Text &amp; Icons"
-            android:summary="Text and icon color for main action buttons" />
-
-        <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_textbox_background"
-            android:title="Text Box Background"
-            android:summary="Background color for text input fields" />
-
-        <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_textbox_accent"
-            android:title="Text Box Border/Accent"
-            android:summary="Border or accent color for text input fields" />
-
-        <com.drgraff.speakkey.settings.ColorPickerPreference
-            android:key="pref_oled_accent_general"
-            android:title="General Accent Color"
-            android:summary="Accent color for switches, sliders, other icons" />
-
     </PreferenceCategory>
 
     <PreferenceCategory android:title="InputStick Text Formatting">


### PR DESCRIPTION
This commit refactors the OLED theme customization settings into a new, separate activity accessible from the main settings screen. This improves the organization of the settings menu.

Changes:
1.  **Created `oled_theme_preferences.xml`**:
    *   A new preference XML file (`app/src/main/res/xml/oled_theme_preferences.xml`) was created.
    *   All `ColorPickerPreference` items related to OLED theme customization were moved from `root_preferences.xml` to this new file under a `PreferenceScreen`.

2.  **Modified `root_preferences.xml`**:
    *   Removed the "OLED Theme Customizations" `PreferenceCategory` and its child color picker preferences.
    *   Added a new `<Preference>` with the key `"pref_oled_theme_settings_screen"` to the "App Settings" category. This preference serves as a link to the new dedicated OLED settings screen.

3.  **Created `activity_oled_theme_settings.xml`**:
    *   A new layout file for the dedicated OLED settings activity. It includes a Toolbar and a `FrameLayout` (`settings_container`) to host the preference fragment.

4.  **Created `OledThemeSettingsFragment.java`**:
    *   A new `PreferenceFragmentCompat` subclass that loads preferences from `oled_theme_preferences.xml`.

5.  **Created `OledThemeSettingsActivity.java`**:
    *   A new `AppCompatActivity` to host `OledThemeSettingsFragment`.
    *   It handles its own theme application (including OLED theme via `ThemeManager` and `DynamicThemeApplicator`) and dynamic theme updates (`onResume`, `onSharedPreferenceChanged`) for its frame (toolbar, background).

6.  **Updated `AndroidManifest.xml`**:
    *   Added an `<activity>` entry for `com.drgraff.speakkey.settings.OledThemeSettingsActivity`.
    *   Set its `android:label` to "OLED Theme Settings" and specified `com.drgraff.speakkey.settings.SettingsActivity` as its `parentActivityName` for Up navigation.

7.  **Modified `SettingsActivity.java` (SettingsFragment)**:
    *   In the `onCreatePreferences` method of the inner `SettingsFragment`, an `OnPreferenceClickListener` was added to the `"pref_oled_theme_settings_screen"` preference.
    *   This listener now launches `OledThemeSettingsActivity` when the preference is clicked.