### PR TITLE
Feat: Implement OLED Color Presets

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/settings/OledThemeSettingsFragment.java
+++ b/app/src/main/java/com/drgraff/speakkey/settings/OledThemeSettingsFragment.java
@@ -1,14 +1,156 @@
 package com.drgraff.speakkey.settings;
 
+import android.graphics.Color;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+import android.content.SharedPreferences;
+import android.util.Log; // Added for logging
 import com.drgraff.speakkey.R;
+// Make sure ColorPickerPreference is imported if needed for instanceof, or use FQDN.
+// For now, assuming findPreference returns Preference and direct casting isn't strictly needed
+// if ColorPickerPreference extends Preference and doesn't need specific methods called on it here.
+// import com.drgraff.speakkey.settings.ColorPickerPreference;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class OledThemeSettingsFragment extends PreferenceFragmentCompat {
+
+    public static final String PREF_KEY_OLED_COLOR_PRESET = "pref_oled_color_preset";
+
+    private static final Map<String, Map<String, Integer>> PRESET_COLORS = new HashMap<>();
+
+    static {
+        Map<String, Integer> neonColors = new HashMap<>();
+        neonColors.put("pref_oled_topbar_background", Color.parseColor("#FF00FF")); // Magenta
+        neonColors.put("pref_oled_topbar_text_icon", Color.parseColor("#000000"));    // Black
+        neonColors.put("pref_oled_main_background", Color.parseColor("#000000"));      // Black
+        neonColors.put("pref_oled_surface_background", Color.parseColor("#1A1A1A"));  // Dark Grey
+        neonColors.put("pref_oled_general_text_primary", Color.parseColor("#00FF00")); // Lime Green
+        neonColors.put("pref_oled_general_text_secondary", Color.parseColor("#A0FFA0"));// Light Lime
+        neonColors.put("pref_oled_button_background", Color.parseColor("#FFFF00"));    // Yellow
+        neonColors.put("pref_oled_button_text_icon", Color.parseColor("#000000"));    // Black
+        neonColors.put("pref_oled_textbox_background", Color.parseColor("#101010"));  // Very Dark Grey
+        neonColors.put("pref_oled_textbox_accent", Color.parseColor("#FF00FF"));       // Magenta
+        neonColors.put("pref_oled_accent_general", Color.parseColor("#00FFFF"));       // Cyan accent
+        PRESET_COLORS.put("neon", neonColors);
+
+        Map<String, Integer> forestColors = new HashMap<>();
+        forestColors.put("pref_oled_topbar_background", Color.parseColor("#2E7D32")); // Dark Green
+        forestColors.put("pref_oled_topbar_text_icon", Color.parseColor("#FFFFFF"));    // White
+        forestColors.put("pref_oled_main_background", Color.parseColor("#000000"));      // Black
+        forestColors.put("pref_oled_surface_background", Color.parseColor("#101010"));  // Very Dark Grey
+        forestColors.put("pref_oled_general_text_primary", Color.parseColor("#A5D6A7")); // Light Green
+        forestColors.put("pref_oled_general_text_secondary", Color.parseColor("#81C784"));// Medium Light Green
+        forestColors.put("pref_oled_button_background", Color.parseColor("#558B2F"));    // Olive Green
+        forestColors.put("pref_oled_button_text_icon", Color.parseColor("#FFFFFF"));    // White
+        forestColors.put("pref_oled_textbox_background", Color.parseColor("#0A0A0A"));  // Near Black
+        forestColors.put("pref_oled_textbox_accent", Color.parseColor("#A5D6A7"));       // Light Green
+        forestColors.put("pref_oled_accent_general", Color.parseColor("#FFB300"));       // Amber accent
+        PRESET_COLORS.put("forest", forestColors);
+
+        Map<String, Integer> oceanColors = new HashMap<>();
+        oceanColors.put("pref_oled_topbar_background", Color.parseColor("#0277BD")); // Deep Blue
+        oceanColors.put("pref_oled_topbar_text_icon", Color.parseColor("#FFFFFF"));    // White
+        oceanColors.put("pref_oled_main_background", Color.parseColor("#000000"));      // Black
+        oceanColors.put("pref_oled_surface_background", Color.parseColor("#0D0D0D"));  // Dark Grey
+        oceanColors.put("pref_oled_general_text_primary", Color.parseColor("#B3E5FC")); // Light Sky Blue
+        oceanColors.put("pref_oled_general_text_secondary", Color.parseColor("#81D4FA"));// Medium Sky Blue
+        oceanColors.put("pref_oled_button_background", Color.parseColor("#039BE5"));    // Bright Blue
+        oceanColors.put("pref_oled_button_text_icon", Color.parseColor("#FFFFFF"));    // White
+        oceanColors.put("pref_oled_textbox_background", Color.parseColor("#0A0A0A"));  // Near Black
+        oceanColors.put("pref_oled_textbox_accent", Color.parseColor("#81D4FA"));       // Medium Sky Blue
+        oceanColors.put("pref_oled_accent_general", Color.parseColor("#FFCA28"));       // Amber/Gold accent
+        PRESET_COLORS.put("ocean", oceanColors);
+    }
+
+    public static Map<String, Integer> getPresetColors(String presetName) {
+        return PRESET_COLORS.get(presetName);
+    }
 
     @Override
     public void onCreatePreferences(@Nullable Bundle savedInstanceState, @Nullable String rootKey) {
         setPreferencesFromResource(R.xml.oled_theme_preferences, rootKey);
+
+        ListPreference presetPreference = findPreference(PREF_KEY_OLED_COLOR_PRESET);
+        if (presetPreference != null) {
+            // Set initial summary based on current value
+            updatePresetSummary(presetPreference, getPreferenceManager().getSharedPreferences().getString(PREF_KEY_OLED_COLOR_PRESET, "custom"));
+
+            presetPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                String selectedPresetKey = (String) newValue;
+                updatePresetSummary((ListPreference) preference, selectedPresetKey);
+
+                if (!"custom".equals(selectedPresetKey)) {
+                    Map<String, Integer> colors = getPresetColors(selectedPresetKey);
+                    if (colors != null) {
+                        SharedPreferences.Editor editor = getPreferenceManager().getSharedPreferences().edit();
+                        for (Map.Entry<String, Integer> entry : colors.entrySet()) {
+                            editor.putInt(entry.getKey(), entry.getValue());
+                            // Individual ColorPickerPreferences will be updated when the activity/fragment is recreated
+                            // due to the SharedPreferences change triggering listeners in the hosting activity.
+                        }
+                        editor.apply();
+                        // The apply() will trigger onSharedPreferenceChanged in SettingsActivity/OledThemeSettingsActivity,
+                        // which should lead to a recreate() call, refreshing the entire UI including ColorPickerPreferences.
+                    }
+                }
+                return true; // Value is persisted
+            });
+        }
+
+        // Logic to update preset dropdown when individual colors change
+        final String[] oledColorKeys = {
+            "pref_oled_topbar_background", "pref_oled_topbar_text_icon",
+            "pref_oled_main_background", "pref_oled_surface_background",
+            "pref_oled_general_text_primary", "pref_oled_general_text_secondary",
+            "pref_oled_button_background", "pref_oled_button_text_icon",
+            "pref_oled_textbox_background", "pref_oled_textbox_accent",
+            "pref_oled_accent_general"
+        };
+
+        if (presetPreference == null) { // Check again in case it was null earlier and we returned from that block
+            Log.e("OledThemeSettingsFrag", "Preset ListPreference is null, cannot attach individual color listeners.");
+            return; // Cannot proceed
+        }
+        // Re-assign to a final variable for use in lambda, if not already effectively final
+        final ListPreference finalPresetPreference = presetPreference;
+
+        Preference.OnPreferenceChangeListener individualColorChangeListener = (preference, newValue) -> {
+            if (!"custom".equals(finalPresetPreference.getValue())) {
+                finalPresetPreference.setValue("custom"); // This will trigger its own listener, which updates summary
+            } else {
+                // If already "custom", ensure summary reflects this.
+                // The presetPreference's own listener should handle this when its value is set.
+                // However, if a color changes while "custom" is already selected,
+                // the preset's listener won't fire again. So, explicitly update summary here too.
+                updatePresetSummary(finalPresetPreference, "custom");
+            }
+            return true; // Allow the individual color change to be persisted
+        };
+
+        for (String key : oledColorKeys) {
+            Preference colorPickerPref = findPreference(key);
+            if (colorPickerPref != null) { // Check if the preference itself exists
+                 // Optional: Check instanceof if ColorPickerPreference has specific methods to call
+                 // if (colorPickerPref instanceof com.drgraff.speakkey.settings.ColorPickerPreference) {
+                    colorPickerPref.setOnPreferenceChangeListener(individualColorChangeListener);
+                 // }
+            } else {
+                Log.w("OledThemeSettingsFrag", "ColorPickerPreference with key '" + key + "' not found.");
+            }
+        }
+    }
+
+    private void updatePresetSummary(ListPreference listPreference, String value) {
+        int index = listPreference.findIndexOfValue(value);
+        if (index >= 0) {
+            listPreference.setSummary(listPreference.getEntries()[index]);
+        } else {
+            listPreference.setSummary("Custom"); // Fallback for "custom" or if value not found
+        }
     }
 }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -69,4 +69,18 @@
         <item>oled</item>
         <item>default</item>
     </string-array>
+
+    <!-- OLED Color Preset Options -->
+    <string-array name="oled_color_preset_entries">
+        <item>Custom</item>
+        <item>Neon</item>
+        <item>Forest</item>
+        <item>Ocean</item>
+    </string-array>
+    <string-array name="oled_color_preset_entry_values">
+        <item>custom</item>
+        <item>neon</item>
+        <item>forest</item>
+        <item>ocean</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/xml/oled_theme_preferences.xml
+++ b/app/src/main/res/xml/oled_theme_preferences.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"> <!-- Assuming app namespace might be used by ColorPickerPreference or other custom prefs if not already declared -->
+
+    <ListPreference
+        android:key="pref_oled_color_preset"
+        android:title="Color Preset"
+        android:summary="Select a predefined color scheme"
+        android:entries="@array/oled_color_preset_entries"
+        android:entryValues="@array/oled_color_preset_entry_values"
+        android:defaultValue="custom" />
 
     <PreferenceCategory android:title="OLED Theme Customizations">
 


### PR DESCRIPTION
This commit introduces a preset system for OLED theme customizations, allowing you to quickly apply predefined color schemes.

Changes:
1.  **Defined Preset Palettes (`OledThemeSettingsFragment.java`):**
    *   Added a static map `PRESET_COLORS` containing three presets: "Neon", "Forest", and "Ocean".
    *   Each preset defines hex color values for all 11 OLED color preferences (e.g., `pref_oled_topbar_background`, `pref_oled_main_background`, `pref_oled_general_text_primary`, `pref_oled_accent_general`, etc.).
    *   Added `PREF_KEY_OLED_COLOR_PRESET` constant.

2.  **Added Preset `ListPreference` (`oled_theme_preferences.xml` & `arrays.xml`):**
    *   A `ListPreference` with the key `pref_oled_color_preset` was added to the top of the `oled_theme_preferences.xml` screen.
    *   Entries ("Custom", "Neon", "Forest", "Ocean") and corresponding entryValues ("custom", "neon", "forest", "ocean") were defined in `arrays.xml`.
    *   The preference defaults to "custom".

3.  **Implemented Preset Application Logic (`OledThemeSettingsFragment.java`):**
    *   An `OnPreferenceChangeListener` is set on the `pref_oled_color_preset` ListPreference.
    *   When a preset is selected (and is not "custom"), the listener retrieves the corresponding color palette.
    *   It then iterates through the palette, updating each of the 11 OLED color SharedPreferences (e.g., `pref_oled_topbar_background`) with the integer color value from the selected preset.
    *   A helper method `updatePresetSummary` was added to keep the ListPreference's summary in sync with its current value.
    *   Changes to SharedPreferences trigger existing `onSharedPreferenceChanged` listeners in activities, leading to `recreate()` calls and visual updates.

4.  **Handled "Custom" State (`OledThemeSettingsFragment.java`):**
    *   An `OnPreferenceChangeListener` was added to each of the 11 individual `ColorPickerPreference` items.
    *   If any individual color is changed by you, this listener programmatically sets the value of the `pref_oled_color_preset` ListPreference to "custom", ensuring the preset dropdown accurately reflects that the current theme is a custom configuration.