### PR TITLE
Feat: Add 4 new detailed OLED color presets

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/settings/OledThemeSettingsFragment.java
+++ b/app/src/main/java/com/drgraff/speakkey/settings/OledThemeSettingsFragment.java
@@ -137,6 +137,66 @@ public class OledThemeSettingsFragment extends PreferenceFragmentCompat {
         mutedModernColors.put("pref_oled_textbox_accent", Color.parseColor("#B0BEC5"));
         mutedModernColors.put("pref_oled_accent_general", Color.parseColor("#FF7043"));
         PRESET_COLORS.put("muted_modern", mutedModernColors);
+
+        // Add Ocean (New)
+        Map<String, Integer> oceanColorsNew = new HashMap<>();
+        oceanColorsNew.put("pref_oled_topbar_background", Color.parseColor("#0D47A1"));
+        oceanColorsNew.put("pref_oled_topbar_text_icon", Color.parseColor("#BBDEFB"));
+        oceanColorsNew.put("pref_oled_main_background", Color.parseColor("#000000"));
+        oceanColorsNew.put("pref_oled_surface_background", Color.parseColor("#011C30"));
+        oceanColorsNew.put("pref_oled_general_text_primary", Color.parseColor("#90CAF9"));
+        oceanColorsNew.put("pref_oled_general_text_secondary", Color.parseColor("#64B5F6"));
+        oceanColorsNew.put("pref_oled_button_background", Color.parseColor("#1976D2"));
+        oceanColorsNew.put("pref_oled_button_text_icon", Color.parseColor("#E3F2FD"));
+        oceanColorsNew.put("pref_oled_textbox_background", Color.parseColor("#E8F5E9")); // Note: This was light green in prompt
+        oceanColorsNew.put("pref_oled_textbox_accent", Color.parseColor("#0D47A1"));
+        oceanColorsNew.put("pref_oled_accent_general", Color.parseColor("#29B6F6"));
+        PRESET_COLORS.put("ocean", oceanColorsNew); // Key "ocean"
+
+        // Add Forest (New)
+        Map<String, Integer> forestColorsNew = new HashMap<>();
+        forestColorsNew.put("pref_oled_topbar_background", Color.parseColor("#1B5E20"));
+        forestColorsNew.put("pref_oled_topbar_text_icon", Color.parseColor("#C8E6C9"));
+        forestColorsNew.put("pref_oled_main_background", Color.parseColor("#000000"));
+        forestColorsNew.put("pref_oled_surface_background", Color.parseColor("#002000"));
+        forestColorsNew.put("pref_oled_general_text_primary", Color.parseColor("#A5D6A7"));
+        forestColorsNew.put("pref_oled_general_text_secondary", Color.parseColor("#81C784"));
+        forestColorsNew.put("pref_oled_button_background", Color.parseColor("#388E3C"));
+        forestColorsNew.put("pref_oled_button_text_icon", Color.parseColor("#E8F5E9"));
+        forestColorsNew.put("pref_oled_textbox_background", Color.parseColor("#E8F5E9"));
+        forestColorsNew.put("pref_oled_textbox_accent", Color.parseColor("#1B5E20"));
+        forestColorsNew.put("pref_oled_accent_general", Color.parseColor("#FFC107"));
+        PRESET_COLORS.put("forest", forestColorsNew); // Key "forest"
+
+        // Add Solar Flare
+        Map<String, Integer> solarFlareColors = new HashMap<>();
+        solarFlareColors.put("pref_oled_topbar_background", Color.parseColor("#FF8C00"));
+        solarFlareColors.put("pref_oled_topbar_text_icon", Color.parseColor("#FFF8E1"));
+        solarFlareColors.put("pref_oled_main_background", Color.parseColor("#000000"));
+        solarFlareColors.put("pref_oled_surface_background", Color.parseColor("#1A1200"));
+        solarFlareColors.put("pref_oled_general_text_primary", Color.parseColor("#FFE082"));
+        solarFlareColors.put("pref_oled_general_text_secondary", Color.parseColor("#FFAB40"));
+        solarFlareColors.put("pref_oled_button_background", Color.parseColor("#FF8C00"));
+        solarFlareColors.put("pref_oled_button_text_icon", Color.parseColor("#FFF8E1"));
+        solarFlareColors.put("pref_oled_textbox_background", Color.parseColor("#FFD54F"));
+        solarFlareColors.put("pref_oled_textbox_accent", Color.parseColor("#FF6F00"));
+        solarFlareColors.put("pref_oled_accent_general", Color.parseColor("#FFB300"));
+        PRESET_COLORS.put("solar_flare", solarFlareColors);
+
+        // Add Cyberpunk
+        Map<String, Integer> cyberpunkColors = new HashMap<>();
+        cyberpunkColors.put("pref_oled_topbar_background", Color.parseColor("#7B1FA2"));
+        cyberpunkColors.put("pref_oled_topbar_text_icon", Color.parseColor("#F8BBD0"));
+        cyberpunkColors.put("pref_oled_main_background", Color.parseColor("#000000"));
+        cyberpunkColors.put("pref_oled_surface_background", Color.parseColor("#10001A"));
+        cyberpunkColors.put("pref_oled_general_text_primary", Color.parseColor("#CE93D8"));
+        cyberpunkColors.put("pref_oled_general_text_secondary", Color.parseColor("#F48FB1"));
+        cyberpunkColors.put("pref_oled_button_background", Color.parseColor("#EC407A"));
+        cyberpunkColors.put("pref_oled_button_text_icon", Color.parseColor("#FCE4EC"));
+        cyberpunkColors.put("pref_oled_textbox_background", Color.parseColor("#F8BBD0"));
+        cyberpunkColors.put("pref_oled_textbox_accent", Color.parseColor("#7B1FA2"));
+        cyberpunkColors.put("pref_oled_accent_general", Color.parseColor("#00BCD4"));
+        PRESET_COLORS.put("cyberpunk", cyberpunkColors);
     }
 
     public static Map<String, Integer> getPresetColors(String presetName) {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -81,6 +81,11 @@
         <item>Mono + Accent</item>
         <item>Retro CRT</item>
         <item>Muted Modern</item>
+        <!-- New entries -->
+        <item>Ocean</item>
+        <item>Forest</item>
+        <item>Solar Flare</item>
+        <item>Cyberpunk</item>
     </string-array>
     <string-array name="oled_color_preset_entry_values">
         <item>custom</item>
@@ -92,5 +97,10 @@
         <item>mono_accent</item>
         <item>retro_crt</item>
         <item>muted_modern</item>
+        <!-- New entry values -->
+        <item>ocean</item>
+        <item>forest</item>
+        <item>solar_flare</item>
+        <item>cyberpunk</item>
     </string-array>
 </resources>


### PR DESCRIPTION
This commit introduces 4 additional preset color schemes for the OLED theme, based on your suggestions, expanding the customization options. The new presets are Ocean, Forest, Solar Flare, and Cyberpunk.

Changes:
1.  **Updated Preset Definitions (`OledThemeSettingsFragment.java`):**
    *   The `PRESET_COLORS` static map in `OledThemeSettingsFragment.java` has been augmented with definitions for "Ocean", "Forest", "Solar Flare", and "Cyberpunk".
    *   Each new preset includes specific color values for all 11 standard OLED theme preferences (e.g., top bar background, main background, text colors, button colors, accent colors), as per the detailed JSON you provided. These are added to the 8 presets from the previous update.

2.  **Updated `arrays.xml`:**
    *   The `<string-array name="oled_color_preset_entries">` has been appended with the display names of the new presets ("Ocean", "Forest", "Solar Flare", "Cyberpunk").
    *   The `<string-array name="oled_color_preset_entry_values">` has been appended with corresponding internal keys ("ocean", "forest", "solar_flare", "cyberpunk") that match the keys in the `PRESET_COLORS` map.

3.  **Verified Existing Logic:**
    *   The existing preset application logic in `OledThemeSettingsFragment.java` was confirmed to be compatible with this expanded list of presets, requiring no modification due to its data-driven design.

Output: