### PR TITLE
Refactor: Update EditTexts to Material Components

### DIFF
--- a/app/src/main/res/layout/activity_photos.xml
+++ b/app/src/main/res/layout/activity_photos.xml
@@ -135,24 +135,27 @@
                 android:gravity="center_vertical"
                 android:layout_marginBottom="8dp">
 
-                <EditText
-                    android:id="@+id/edittext_chatgpt_response_photo"
+                <com.google.android.material.textfield.TextInputLayout
                     android:layout_width="0dp"
                     android:layout_height="180dp"
                     android:layout_weight="1"
-                    android:hint="@string/photos_edittext_chatgpt_response_hint_text"
-                    android:inputType="textMultiLine"
-                    android:minLines="3"
-                    android:maxLines="100"
-                    android:background="@color/edit_text_background"
-                    android:padding="8dp"
-                    android:gravity="top|start"
-                    android:scrollbars="vertical"
-                    android:fadeScrollbars="false"
-                    android:nestedScrollingEnabled="true"
-                    android:focusable="false"
-                    android:clickable="true"
-                    android:drawableEnd="?android:attr/actionModeWebSearchDrawable" />
+                    android:hint="@string/photos_edittext_chatgpt_response_hint_text">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/edittext_chatgpt_response_photo"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:inputType="textMultiLine"
+                        android:minLines="3"
+                        android:maxLines="100"
+                        android:gravity="top|start"
+                        android:scrollbars="vertical"
+                        android:fadeScrollbars="false"
+                        android:nestedScrollingEnabled="true"
+                        android:focusable="false"
+                        android:clickable="true"
+                        android:drawableEnd="?android:attr/actionModeWebSearchDrawable" />
+                </com.google.android.material.textfield.TextInputLayout>
 
                 <LinearLayout
                     android:layout_width="wrap_content"

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -179,24 +179,27 @@
             android:layout_marginTop="0dp"
             android:layout_marginBottom="2dp">
 
-            <EditText
-                android:id="@+id/whisper_text"
+            <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="0dp"
                 android:layout_height="180dp"
                 android:layout_weight="1"
-                android:background="@color/edit_text_background"
-                android:hint="Transcribed text will appear here"
-                android:padding="8dp"
-                android:gravity="top|start"
-                android:inputType="textMultiLine"
-                android:drawableEnd="?android:attr/actionModeWebSearchDrawable"
-                android:focusable="false"
-                android:clickable="true"
-                android:scrollbars="vertical"
-                android:fadeScrollbars="false"
-                android:nestedScrollingEnabled="true"
-                android:minLines="3"
-                android:maxLines="100"/>
+                android:hint="Transcribed text will appear here">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/whisper_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:gravity="top|start"
+                    android:inputType="textMultiLine"
+                    android:drawableEnd="?android:attr/actionModeWebSearchDrawable"
+                    android:focusable="false"
+                    android:clickable="true"
+                    android:scrollbars="vertical"
+                    android:fadeScrollbars="false"
+                    android:nestedScrollingEnabled="true"
+                    android:minLines="3"
+                    android:maxLines="100"/>
+            </com.google.android.material.textfield.TextInputLayout>
 
             <LinearLayout
                 android:layout_width="wrap_content"
@@ -356,24 +359,27 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toTopOf="@id/inputstick_controls">
 
-        <EditText
-            android:id="@+id/chatgpt_text"
+        <com.google.android.material.textfield.TextInputLayout
             android:layout_width="0dp"
             android:layout_height="180dp"
             android:layout_weight="1"
-            android:background="@color/edit_text_background"
-            android:hint="ChatGPT response will appear here"
-            android:padding="8dp"
-            android:gravity="top|start"
-            android:inputType="textMultiLine"
-            android:drawableEnd="?android:attr/actionModeWebSearchDrawable"
-            android:focusable="false"
-            android:clickable="true"
-            android:scrollbars="vertical"
-            android:fadeScrollbars="false"
-            android:nestedScrollingEnabled="true"
-            android:minLines="3"
-            android:maxLines="100"/>
+            android:hint="ChatGPT response will appear here">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/chatgpt_text"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="top|start"
+                android:inputType="textMultiLine"
+                android:drawableEnd="?android:attr/actionModeWebSearchDrawable"
+                android:focusable="false"
+                android:clickable="true"
+                android:scrollbars="vertical"
+                android:fadeScrollbars="false"
+                android:nestedScrollingEnabled="true"
+                android:minLines="3"
+                android:maxLines="100"/>
+        </com.google.android.material.textfield.TextInputLayout>
 
         <LinearLayout
             android:layout_width="wrap_content"


### PR DESCRIPTION
I've updated the EditTexts in MainActivity (content_main.xml) and PhotosActivity (activity_photos.xml) to use `com.google.android.material.textfield.TextInputLayout` and `com.google.android.material.textfield.TextInputEditText`.

This change ensures that the text boxes for:
- Whisper transcription (MainActivity)
- ChatGPT response (MainActivity)
- ChatGPT response (PhotosActivity)

now have a consistent Material Design appearance, including thin borders with rounded corners and appropriate focus behavior, matching the styling of text boxes in EditPromptActivity. I also removed custom background attributes as Material Components handle this styling.