### PR TITLE
Fix: Apply outlined style to text input layouts

### DIFF
--- a/app/src/main/res/layout/activity_photos.xml
+++ b/app/src/main/res/layout/activity_photos.xml
@@ -136,6 +136,7 @@
                 android:layout_marginBottom="8dp">
 
                 <com.google.android.material.textfield.TextInputLayout
+                    style="@style/Widget.App.TextInputLayout.OLED"
                     android:layout_width="0dp"
                     android:layout_height="180dp"
                     android:layout_weight="1"

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -180,6 +180,7 @@
             android:layout_marginBottom="2dp">
 
             <com.google.android.material.textfield.TextInputLayout
+                style="@style/Widget.App.TextInputLayout.OLED"
                 android:layout_width="0dp"
                 android:layout_height="180dp"
                 android:layout_weight="1"
@@ -360,6 +361,7 @@
         app:layout_constraintBottom_toTopOf="@id/inputstick_controls">
 
         <com.google.android.material.textfield.TextInputLayout
+            style="@style/Widget.App.TextInputLayout.OLED"
             android:layout_width="0dp"
             android:layout_height="180dp"
             android:layout_weight="1"


### PR DESCRIPTION
I updated TextInputLayout components in MainActivity (content_main.xml) and PhotosActivity (activity_photos.xml) to use the `@style/Widget.App.TextInputLayout.OLED` style.

This style inherits from MaterialComponents' OutlinedBox, ensuring that the text boxes now render with a visible border and rounded corners as you originally intended.

This addresses the issue where the previous changes resulted in text boxes matching the app color mode but lacking the explicit border and rounded corner styling of an outlined text field.