### PR TITLE
Fix: Enhance visibility of TextInputLayout borders in OLED mode

### DIFF
--- a/app/src/main/res/color/oled_textinput_border_color.xml
+++ b/app/src/main/res/color/oled_textinput_border_color.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Focused and enabled state -->
+    <item android:color="@color/oled_primary" android:state_focused="true" android:state_enabled="true"/>
+    <!-- Unfocused and enabled state (default) -->
+    <item android:color="@color/oled_text_secondary" android:state_enabled="true"/>
+    <!-- Disabled state -->
+    <item android:color="@color/gray" android:state_enabled="false"/>
+    <!-- Default fallback (should ideally be covered by enabled states) -->
+    <item android:color="@color/oled_text_secondary"/>
+</selector>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -82,7 +82,7 @@
 
     <!-- TextInputLayout style for OLED -->
     <style name="Widget.App.TextInputLayout.OLED" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
-        <item name="boxStrokeColor">@color/oled_primary</item>
+        <item name="boxStrokeColor">@color/oled_textinput_border_color</item> <!-- Changed to ColorStateList -->
         <item name="hintTextColor">@color/oled_text_secondary</item>
     </style>
 


### PR DESCRIPTION
I updated the `Widget.App.TextInputLayout.OLED` style to use a ColorStateList for the `boxStrokeColor` attribute. The new ColorStateList (`@color/oled_textinput_border_color`) defines:
- `@color/oled_text_secondary` (70% white) for the unfocused, enabled state.
- `@color/oled_primary` for the focused, enabled state.
- `@color/gray` for the disabled state.

This change makes the text box borders significantly more obvious and persistently visible when unfocused in OLED mode, addressing your feedback that the previous border color (`@color/oled_primary` for all states) was not prominent enough. The focused state retains its distinct accent color.