### PR TITLE
Refactor: Reduce vertical spacing in MainActivity

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -70,7 +70,7 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:gravity="center_vertical"
-        android:layout_marginTop="2dp"
+        android:layout_marginTop="1dp"
         app:layout_constraintTop_toBottomOf="@id/recording_controls"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
@@ -110,7 +110,7 @@
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:gravity="center_horizontal"
-            android:layout_marginTop="2dp">
+            android:layout_marginTop="1dp">
 
             <LinearLayout
                 android:layout_width="wrap_content"
@@ -150,8 +150,8 @@
             android:layout_height="wrap_content"
             android:indeterminate="true"
             android:visibility="gone"
-            android:layout_marginTop="4dp"
-            android:layout_marginBottom="4dp"/>
+            android:layout_marginTop="2dp"
+            android:layout_marginBottom="2dp"/>
 
         <TextView
             android:id="@+id/textViewWhisperStatus"
@@ -160,15 +160,15 @@
             android:text=""
             android:gravity="center_horizontal"
             android:visibility="gone"
-            android:layout_marginBottom="4dp"/>
+            android:layout_marginBottom="2dp"/>
 
         <LinearLayout
             android:id="@+id/whisper_text_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:layout_marginTop="4dp"
-            android:layout_marginBottom="2dp">
+            android:layout_marginTop="2dp"
+            android:layout_marginBottom="1dp">
 
             <com.google.android.material.textfield.TextInputLayout
                 style="@style/Widget.App.TextInputLayout.OLED"
@@ -225,7 +225,7 @@
             android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:gravity="center"
-            android:layout_marginTop="2dp"
+            android:layout_marginTop="1dp"
             android:layout_marginBottom="0dp">
             <!-- The Button @+id/btn_clear_transcription was here.
                  The bottom constraint of whisper_to_inputstick_controls needs to point to chatgpt_controls -->
@@ -252,7 +252,7 @@
         android:layout_marginTop="0dp"
         android:layout_marginBottom="0dp"
         android:gravity="center_horizontal"
-        android:paddingVertical="2dp"
+        android:paddingVertical="1dp"
         android:paddingHorizontal="8dp"
         android:text="Active Prompts Area"
         android:textAppearance="?android:attr/textAppearanceMedium"
@@ -310,8 +310,8 @@
         android:layout_height="wrap_content"
         android:indeterminate="true"
         android:visibility="gone"
-        android:layout_marginTop="4dp"
-        android:layout_marginBottom="4dp"
+        android:layout_marginTop="2dp"
+        android:layout_marginBottom="2dp"
         app:layout_constraintTop_toBottomOf="@id/chatgpt_controls"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
@@ -323,7 +323,7 @@
         android:text=""
         android:gravity="center_horizontal"
         android:visibility="gone"
-        android:layout_marginBottom="4dp"
+        android:layout_marginBottom="2dp"
         app:layout_constraintTop_toBottomOf="@id/progressBarChatGpt"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
@@ -333,7 +333,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:layout_marginTop="10dp"
+        android:layout_marginTop="4dp"
         android:layout_marginBottom="2dp"
         app:layout_constraintTop_toBottomOf="@id/textViewChatGptStatus"
         app:layout_constraintStart_toStartOf="parent"
@@ -396,7 +396,7 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:gravity="center"
-        android:layout_marginTop="4dp"
+        android:layout_marginTop="2dp"
         android:layout_marginBottom="2dp"
         app:layout_constraintTop_toBottomOf="@id/chatgpt_text_container"
         app:layout_constraintBottom_toBottomOf="parent">


### PR DESCRIPTION
I've reduced various vertical margins and paddings within `content_main.xml` to make the layout in MainActivity more compact.

Specific areas I addressed:
- Space between recording controls and active prompts display (by tightening margins within the Whisper section).
- Padding of the active prompts display area.
- Space between ChatGPT controls and the ChatGPT text input area (including margins for progress bar and status).
- Space between the ChatGPT text input area and the InputStick controls.

These changes respond to your feedback about excessive blank space in these sections of the UI.