### PR TITLE
Fix: Apply OLED theme styling to full-screen text editor dialog

### DIFF
--- a/app/src/main/res/layout/dialog_edit_text_fullscreen.xml
+++ b/app/src/main/res/layout/dialog_edit_text_fullscreen.xml
@@ -4,17 +4,24 @@
     android:layout_height="match_parent"
     android:padding="16dp">
 
-    <EditText
-        android:id="@+id/edit_text_fullscreen_content"
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/text_input_layout_fullscreen"
+        style="@style/Widget.App.TextInputLayout.OLED"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_above="@+id/btn_save_fullscreen_edit"
         android:layout_alignParentTop="true"
-        android:gravity="top|start"
-        android:inputType="textMultiLine"
-        android:padding="8dp"
-        android:scrollbars="vertical"
-        android:hint="Enter text here..."/>
+        android:hint="Enter text here...">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/edit_text_fullscreen_content"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="top|start"
+            android:inputType="textMultiLine"
+            android:scrollbars="vertical"/>
+
+    </com.google.android.material.textfield.TextInputLayout>
 
     <Button
         android:id="@+id/btn_save_fullscreen_edit"


### PR DESCRIPTION
I modified `dialog_edit_text_fullscreen.xml` to improve the theming of the pop-up text editor. The `EditText` within the dialog has been replaced with a `com.google.android.material.textfield.TextInputEditText` wrapped in a `com.google.android.material.textfield.TextInputLayout`.

The `TextInputLayout` is now styled with
`@style/Widget.App.TextInputLayout.OLED`. This ensures that the text input area in the full-screen editor dialog consistently displays with an outlined box, rounded corners, a persistent border (using `@color/oled_textinput_border_color` state list), and appropriate text/hint colors for the OLED theme.

This change makes the full-screen editor's appearance match the styling of text boxes in `EditPromptActivity` and other styled text inputs in the application, addressing your feedback about inconsistent theming in the pop-up editor.