### PR TITLE
Fix: Correct OLED theming for full-screen editor dialog

### DIFF
--- a/app/src/main/res/layout/dialog_edit_text_fullscreen.xml
+++ b/app/src/main/res/layout/dialog_edit_text_fullscreen.xml
@@ -2,7 +2,8 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="16dp">
+    android:padding="16dp"
+    android:background="?android:attr/colorBackground">
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/text_input_layout_fullscreen"
@@ -25,6 +26,7 @@
 
     <Button
         android:id="@+id/btn_save_fullscreen_edit"
+        style="@style/Widget.App.Button.OLED.Dialog"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -99,4 +99,12 @@
         <item name="navigationIconTint">@color/oled_icon_tint</item> <!-- For Up button, etc. -->
         <item name="iconTint">@color/oled_icon_tint</item> <!-- For menu items if not overridden by action menu style -->
     </style>
+
+    <!-- Button style for OLED Dialogs -->
+    <style name="Widget.App.Button.OLED.Dialog" parent="Widget.MaterialComponents.Button">
+        <item name="android:backgroundTint">@color/oled_surface</item> <!-- Or @color/oled_edit_text_background -->
+        <item name="android:textColor">@color/oled_primary</item>
+        <item name="android:paddingLeft">16dp</item>
+        <item name="android:paddingRight">16dp</item>
+    </style>
 </resources>


### PR DESCRIPTION
I've addressed styling issues in the full-screen text editor dialog (`dialog_edit_text_fullscreen.xml`) to ensure consistency with the OLED theme.

Changes include:
1.  Set the `android:background` of the dialog's root `RelativeLayout` to `?android:attr/colorBackground`. This ensures the dialog background correctly uses `@color/oled_background` (black) when `AppTheme.OLED` is active, resolving the previous grey background issue.
2.  Defined a new button style `Widget.App.Button.OLED.Dialog` in `themes.xml` which uses `@color/oled_surface` for the background tint and `@color/oled_primary` for the text color.
3.  Applied this new style to the "Save" button within the dialog, making its appearance consistent with the OLED theme and resolving the issue of it having a default purple background.

The text input field within the dialog was previously updated to use `Widget.App.TextInputLayout.OLED` for correct border and text styling. With these additional changes, the entire full-screen editor dialog should now correctly adhere to your application's OLED theme.