### PR TITLE
Fix: Correct Save button styling in full-screen editor for OLED theme

### DIFF
--- a/app/src/main/res/layout/dialog_edit_text_fullscreen.xml
+++ b/app/src/main/res/layout/dialog_edit_text_fullscreen.xml
@@ -26,7 +26,6 @@
 
     <Button
         android:id="@+id/btn_save_fullscreen_edit"
-        style="@style/Widget.App.Button.OLED.Dialog"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"


### PR DESCRIPTION
Reverted the "Save" button (`btn_save_fullscreen_edit`) in the `dialog_edit_text_fullscreen.xml` layout to use the default Material Components button style by removing a previously applied custom style.

When the `AppTheme.OLED` is active in the hosting activity, the default button style correctly uses `?attr/colorPrimary` (i.e., `@color/oled_primary` - purple) for its background and `?attr/colorOnPrimary` (i.e., `@color/black`) for its text color.

This change ensures the "Save" button in the full-screen editor dialog now visually matches the "Save" button in the `EditPromptActivity` (Add New Prompt activity) under the OLED theme, as per your feedback. The previous custom style that resulted in a dark grey background with purple text has been removed from this button.