### PR TITLE
It looks like the "Save" buttons in `dialog_edit_text_fullscreen.xml`…

### DIFF
--- a/app/src/main/res/layout/activity_edit_prompt.xml
+++ b/app/src/main/res/layout/activity_edit_prompt.xml
@@ -73,6 +73,7 @@
 
         <Button
             android:id="@+id/button_save_prompt"
+            style="@style/Widget.App.Button.OLED.PrimaryAction"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end"

--- a/app/src/main/res/layout/dialog_edit_text_fullscreen.xml
+++ b/app/src/main/res/layout/dialog_edit_text_fullscreen.xml
@@ -26,6 +26,7 @@
 
     <Button
         android:id="@+id/btn_save_fullscreen_edit"
+        style="@style/Widget.App.Button.OLED.PrimaryAction"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -107,4 +107,13 @@
         <item name="android:paddingLeft">16dp</item>
         <item name="android:paddingRight">16dp</item>
     </style>
+
+    <!-- Custom Button style for OLED primary actions -->
+    <style name="Widget.App.Button.OLED.PrimaryAction" parent="Widget.MaterialComponents.Button">
+        <item name="android:backgroundTint">@color/oled_secondary</item> <!-- Cyan background -->
+        <item name="android:textColor">@color/black</item>           <!-- Black text -->
+        <item name="app:iconTint">@color/black</item>                <!-- Black icon tint -->
+        <item name="android:paddingLeft">16dp</item>
+        <item name="android:paddingRight">16dp</item>
+    </style>
 </resources>


### PR DESCRIPTION
… and `activity_edit_prompt.xml` have been updated. They now use a new common style called `Widget.App.Button.OLED.PrimaryAction`.

This new style, which you can find in `themes.xml`, changes the button's background to `@color/oled_secondary` (Cyan) and the text/icon color to `@color/black`. This matches the default OLED button colors set in `DynamicThemeApplicator.java` (`DEFAULT_OLED_BUTTON_BACKGROUND` and `DEFAULT_OLED_BUTTON_TEXT_ICON`).

This update makes sure these main action buttons consistently show the intended custom OLED button look. Before, they were defaulting to the theme's `colorPrimary` for their background (making them purple) or using other temporary custom styles.