### PR TITLE
Fix: Correct iconTint attribute in OLED button style to resolve build…

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -112,7 +112,7 @@
     <style name="Widget.App.Button.OLED.PrimaryAction" parent="Widget.MaterialComponents.Button">
         <item name="android:backgroundTint">@color/oled_secondary</item> <!-- Cyan background -->
         <item name="android:textColor">@color/black</item>           <!-- Black text -->
-        <item name="app:iconTint">@color/black</item>                <!-- Black icon tint -->
+        <item name="iconTint">@color/black</item>                <!-- Black icon tint (Corrected) -->
         <item name="android:paddingLeft">16dp</item>
         <item name="android:paddingRight">16dp</item>
     </style>


### PR DESCRIPTION
… error

I corrected the `Widget.App.Button.OLED.PrimaryAction` style definition in `app/src/main/res/values/themes.xml`. The item for icon tinting was changed from `<item name="app:iconTint">@color/black</item>` to `<item name="iconTint">@color/black</item>`.

The previous use of `app:iconTint` as a style item name was incorrect and caused an "attribute not found" resource linking error during the build process. Using `iconTint` directly is the correct way to set this Material Components attribute within a style definition.

This change resolves the build failure.