### PR TITLE
Refactor: Standardize text box appearance

### DIFF
--- a/app/src/main/res/layout/activity_photos.xml
+++ b/app/src/main/res/layout/activity_photos.xml
@@ -136,7 +136,6 @@
                 android:layout_marginBottom="8dp">
 
                 <com.google.android.material.textfield.TextInputLayout
-                    style="@style/Widget.App.TextInputLayout.OLED"
                     android:layout_width="0dp"
                     android:layout_height="180dp"
                     android:layout_weight="1"

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -171,7 +171,6 @@
             android:layout_marginBottom="1dp">
 
             <com.google.android.material.textfield.TextInputLayout
-                style="@style/Widget.App.TextInputLayout.OLED"
                 android:layout_width="0dp"
                 android:layout_height="180dp"
                 android:layout_weight="1"
@@ -341,7 +340,6 @@
         app:layout_constraintBottom_toTopOf="@id/inputstick_controls">
 
         <com.google.android.material.textfield.TextInputLayout
-            style="@style/Widget.App.TextInputLayout.OLED"
             android:layout_width="0dp"
             android:layout_height="180dp"
             android:layout_weight="1"


### PR DESCRIPTION
Removed explicit OLED styling from text input layouts in MainActivity and PhotosActivity to ensure they use the default application theme styling, matching PromptEditActivity.