### PR TITLE
Refactor: Make EditTexts in Main and Photos Activities directly editable

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/PhotosActivity.java
@@ -69,7 +69,7 @@ import com.drgraff.speakkey.service.UploadService;
 import com.drgraff.speakkey.inputstick.InputStickManager;
 import com.drgraff.speakkey.settings.SettingsActivity;
 import com.drgraff.speakkey.utils.AppLogManager;
-import com.drgraff.speakkey.FullScreenEditTextDialogFragment; // Keep for now, remove if class deleted
+// import com.drgraff.speakkey.FullScreenEditTextDialogFragment; // REMOVED
 
 public class PhotosActivity extends AppCompatActivity implements SharedPreferences.OnSharedPreferenceChangeListener { // FullScreenEditTextDialogFragment.OnSaveListener REMOVED
 


### PR DESCRIPTION
Replaces the FullScreenEditTextDialogFragment with inline editing for a more seamless user experience.

- Modified EditText attributes in `content_main.xml` and `activity_photos.xml` to enable direct focus and input.
- Removed `OnClickListener`s from `MainActivity.java` and `PhotosActivity.java` that previously launched the dialog.
- Deleted `FullScreenEditTextDialogFragment.java` and its layout `dialog_edit_text_fullscreen.xml` as they are no longer used.
- Removed associated `OnSaveListener` interface implementations and unused fields/methods from `MainActivity` and `PhotosActivity`.
- Fixed build error by removing unused import for FullScreenEditTextDialogFragment in PhotosActivity.