### PR TITLE
Fix: Apply OLED theme to settings dialogs

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -71,6 +71,19 @@
         <!-- Control colors for widgets like CheckBox, Switch, RadioButton -->
         <item name="colorControlActivated">@color/oled_secondary</item>
         <item name="colorControlNormal">@color/oled_text_secondary</item>
+        <item name="alertDialogTheme">@style/AppTheme.OLED.AlertDialogStyle</item>
+    </style>
+
+    <style name="AppTheme.OLED.AlertDialogStyle" parent="ThemeOverlay.MaterialComponents.Dialog.Alert">
+        <item name="android:background">@color/oled_surface</item> <!-- Dialog window background -->
+        <item name="colorSurface">@color/oled_surface</item> <!-- Surface color for dialog components -->
+        <item name="android:textColorPrimary">@color/oled_text_primary</item>
+        <item name="android:textColorSecondary">@color/oled_text_secondary</item>
+        <item name="buttonBarPositiveButtonStyle">@style/Widget.App.Button.OLED.Dialog</item>
+        <item name="buttonBarNegativeButtonStyle">@style/Widget.App.Button.OLED.Dialog</item>
+        <item name="buttonBarNeutralButtonStyle">@style/Widget.App.Button.OLED.Dialog</item>
+        <!-- For ListPreference item selection -->
+        <item name="colorControlActivated">@color/oled_secondary</item>
     </style>
 
     <style name="Widget.App.NavigationView.OLED" parent="Widget.Design.NavigationView">


### PR DESCRIPTION
Ensures that dialogs launched from the SettingsActivity (ListPreference, EditTextPreference, ProgressDialog) correctly adhere to the OLED theme.

- Created a new style `AppTheme.OLED.AlertDialogStyle` in `themes.xml` that defines OLED-specific colors for dialog backgrounds, text, and buttons.
- Applied this style to `AppTheme.OLED` using the `alertDialogTheme` attribute.
- This ensures that standard preference dialogs and the ProgressDialog inherit the correct OLED theming when the OLED theme is active.