### PR TITLE
Fix: Refine OLED dialog control colors

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -82,8 +82,8 @@
         <item name="buttonBarPositiveButtonStyle">@style/Widget.App.Button.OLED.Dialog</item>
         <item name="buttonBarNegativeButtonStyle">@style/Widget.App.Button.OLED.Dialog</item>
         <item name="buttonBarNeutralButtonStyle">@style/Widget.App.Button.OLED.Dialog</item>
-        <!-- For ListPreference item selection -->
-        <item name="colorControlActivated">@color/oled_secondary</item>
+        <!-- For ListPreference item selection - Changed from oled_secondary to oled_text_primary -->
+        <item name="colorControlActivated">@color/oled_text_primary</item>
     </style>
 
     <style name="Widget.App.NavigationView.OLED" parent="Widget.Design.NavigationView">
@@ -116,7 +116,7 @@
     <!-- Button style for OLED Dialogs -->
     <style name="Widget.App.Button.OLED.Dialog" parent="Widget.MaterialComponents.Button">
         <item name="android:backgroundTint">@color/oled_surface</item> <!-- Or @color/oled_edit_text_background -->
-        <item name="android:textColor">@color/oled_primary</item>
+        <item name="android:textColor">@color/oled_text_primary</item> <!-- Changed from oled_primary -->
         <item name="android:paddingLeft">16dp</item>
         <item name="android:paddingRight">16dp</item>
     </style>


### PR DESCRIPTION
- Changed `colorControlActivated` in `AppTheme.OLED.AlertDialogStyle` to `@color/oled_text_primary` to make selected radio button accents white instead of cyan in OLED dialogs.
- Changed `android:textColor` in `Widget.App.Button.OLED.Dialog` to `@color/oled_text_primary` to make dialog button text white instead of purple in OLED dialogs.

These changes provide a more consistent and neutral appearance for controls within dialogs when the OLED theme is active.