### PR TITLE
Feat: Add setting for adjustable macro button height

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -1764,9 +1764,26 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             button.setText(macro.getName());
             button.setEllipsize(TextUtils.TruncateAt.END); // Ellipsize long text
             button.setMaxLines(2); // Allow up to 2 lines, then ellipsize
+
+            // Get preferred button height
+            String buttonHeightSetting = sharedPreferences.getString("pref_macro_button_height", "medium");
+            int buttonHeightInPx;
+            switch (buttonHeightSetting) {
+                case "small":
+                    buttonHeightInPx = (int) getResources().getDimension(R.dimen.macro_button_height_small);
+                    break;
+                case "large":
+                    buttonHeightInPx = (int) getResources().getDimension(R.dimen.macro_button_height_large);
+                    break;
+                case "medium":
+                default:
+                    buttonHeightInPx = (int) getResources().getDimension(R.dimen.macro_button_height_medium);
+                    break;
+            }
+
             LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
                     0, // width
-                    LinearLayout.LayoutParams.WRAP_CONTENT, // height
+                    buttonHeightInPx, // height
                     1.0f // weight
             );
             params.setMargins(marginHorizontalPx, 0, marginHorizontalPx, 0);

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -113,4 +113,16 @@
         <item>void</item>
         <item>candy_pop</item>
     </string-array>
+
+    <!-- Macro Button Height Options -->
+    <string-array name="macro_button_height_entries">
+        <item>Small</item>
+        <item>Medium (Default)</item>
+        <item>Large</item>
+    </string-array>
+    <string-array name="macro_button_height_values">
+        <item>small</item>
+        <item>medium</item>
+        <item>large</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="macro_button_margin_horizontal">4dp</dimen>
+
+    <!-- Macro Button Heights -->
+    <dimen name="macro_button_height_small">40dp</dimen>
+    <dimen name="macro_button_height_medium">56dp</dimen>
+    <dimen name="macro_button_height_large">72dp</dimen>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -110,6 +110,14 @@
             android:title="@string/settings_auto_send_inputstick_title"
             android:summary="@string/settings_auto_send_inputstick_summary"
             android:defaultValue="false" />
+
+        <ListPreference
+            android:key="pref_macro_button_height"
+            android:title="Macro Button Height"
+            android:summary="%s"
+            android:entries="@array/macro_button_height_entries"
+            android:entryValues="@array/macro_button_height_values"
+            android:defaultValue="medium" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="InputStick Text Formatting">


### PR DESCRIPTION
- Added a ListPreference ('pref_macro_button_height') to app settings allowing users to choose between Small, Medium (Default), and Large heights for macro buttons.
- Defined corresponding dp values (40dp, 56dp, 72dp) in `dimens.xml`.
- Updated `MainActivity.displayActiveMacros()` to read this preference and apply the selected height to the dynamically generated macro buttons.
- Set preference summary to '%s' for automatic updates in `root_preferences.xml`.