### PR TITLE
Feat: Add 'Extra Large' option for macro button height

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -1775,6 +1775,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                 case "large":
                     buttonHeightInPx = (int) getResources().getDimension(R.dimen.macro_button_height_large);
                     break;
+                case "xlarge":
+                    buttonHeightInPx = (int) getResources().getDimension(R.dimen.macro_button_height_xlarge);
+                    break;
                 case "medium":
                 default:
                     buttonHeightInPx = (int) getResources().getDimension(R.dimen.macro_button_height_medium);

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -119,10 +119,12 @@
         <item>Small</item>
         <item>Medium (Default)</item>
         <item>Large</item>
+        <item>Extra Large</item>
     </string-array>
     <string-array name="macro_button_height_values">
         <item>small</item>
         <item>medium</item>
         <item>large</item>
+        <item>xlarge</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -6,4 +6,5 @@
     <dimen name="macro_button_height_small">40dp</dimen>
     <dimen name="macro_button_height_medium">56dp</dimen>
     <dimen name="macro_button_height_large">72dp</dimen>
+    <dimen name="macro_button_height_xlarge">88dp</dimen>
 </resources>


### PR DESCRIPTION
- Added 'Extra Large' (value 'xlarge') to the macro button height preference entries/values in `arrays.xml`.
- Defined `macro_button_height_xlarge` as 88dp in `dimens.xml`.
- Updated `MainActivity.displayActiveMacros()` to handle the 'xlarge' case and apply the new dimension.