### PR TITLE
Fix: Prevent keyboard auto-popup in MainActivity

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -1591,6 +1591,15 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         displayActiveMacros(); // Moved here
         refreshTranscriptionStatus(false); // false because it's an automatic refresh onResume
         Log.d(TAG, "onResume: All UI setup calls complete in onResume.");
+
+        // Request focus on a non-EditText view to prevent keyboard from popping up
+        View dummyFocusableView = findViewById(R.id.dummy_focusable_view);
+        if (dummyFocusableView != null) {
+            dummyFocusableView.requestFocus();
+        }
+        // Alternative: Clear focus from specific EditTexts
+        // if (whisperText != null) whisperText.clearFocus();
+        // if (chatGptText != null) chatGptText.clearFocus();
     }
 
     @Override

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -10,6 +10,21 @@
 <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:descendantFocusability="beforeDescendants">
+
+    <LinearLayout
+        android:id="@+id/dummy_focusable_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:orientation="horizontal"/>
+
+    <LinearLayout
+        android:id="@+id/active_macros_rows_container"
+        android:layout_width="match_parent"
     android:padding="16dp"
     tools:context=".MainActivity"
     tools:showIn="@layout/app_bar_main">


### PR DESCRIPTION
- Added a 0dp x 0dp focusable LinearLayout (dummy_focusable_view) to `content_main.xml`.
- Programmatically requested focus for this dummy view in `MainActivity.onResume()`.
- This ensures that an EditText does not retain focus when the activity starts or resumes, preventing the soft keyboard from automatically appearing.