### PR TITLE
Feat: Enable sharing audio and image files to SpeakKey

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -10,7 +10,10 @@
 <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:descendantFocusability="beforeDescendants">
+    android:descendantFocusability="beforeDescendants"
+    android:padding="16dp"
+    tools:context=".MainActivity"
+    tools:showIn="@layout/app_bar_main">
 
     <LinearLayout
         android:id="@+id/dummy_focusable_view"


### PR DESCRIPTION
- Created `ShareDispatcherActivity` to handle ACTION_SEND intents for audio and image MIME types.
- Added intent filters to `AndroidManifest.xml` for `ShareDispatcherActivity` to accept `audio/*` and `image/*`.
- Implemented a file copying utility in `ShareDispatcherActivity` to save shared content URIs to local app cache.
- For shared audio:
    - `ShareDispatcherActivity` copies the audio file locally.
    - Creates an `UploadTask` for transcription (simulating auto-send recording flow).
    - Starts `UploadService` to process the audio.
- For shared images:
    - `ShareDispatcherActivity` copies the image file locally.
    - Starts `PhotosActivity`, passing the local image path as an extra.
- Modified `PhotosActivity.onCreate()` to detect the incoming shared image path, load the image, and automatically trigger the vision processing (simulating auto-send photo flow).
- Fixed XML structure error in `content_main.xml` that occurred in a previous commit.