### PR TITLE
Feat: Enable sharing audio and image files to SpeakKey

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -28,17 +28,10 @@
     <LinearLayout
         android:id="@+id/active_macros_rows_container"
         android:layout_width="match_parent"
-    android:padding="16dp"
-    tools:context=".MainActivity"
-    tools:showIn="@layout/app_bar_main">
-
-    <LinearLayout
-        android:id="@+id/active_macros_rows_container"
-        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:layout_marginBottom="2dp"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/dummy_focusable_view"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toTopOf="@id/recording_controls"


### PR DESCRIPTION
- Created `ShareDispatcherActivity` to handle ACTION_SEND intents for audio and image MIME types.
- Added intent filters to `AndroidManifest.xml` for `ShareDispatcherActivity` to accept `audio/*` and `image/*`.
- Implemented a file copying utility in `ShareDispatcherActivity` to save shared content URIs to local app cache.
- For shared audio:
    - `ShareDispatcherActivity` copies the audio file locally.
    - Creates an `UploadTask` for transcription (simulating auto-send recording flow).
    - Starts `UploadService` to process the audio.
- For shared images:
    - `ShareDispatcherActivity` copies the image file locally.
    - Starts `PhotosActivity`, passing the local image path as an extra.
- Modified `PhotosActivity.onCreate()` to detect the incoming shared image path, load the image, and automatically trigger the vision processing (simulating auto-send photo flow).
- Corrected XML structure in `content_main.xml` to resolve build errors.