### PR TITLE
Fix: Resolve build errors from shared audio handling changes

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/data/UploadTask.java
+++ b/app/src/main/java/com/drgraff/speakkey/data/UploadTask.java
@@ -9,7 +9,7 @@ import androidx.room.PrimaryKey;
 public class UploadTask {
 
     @PrimaryKey(autoGenerate = true)
-    public int id;
+    public long id; // Changed from int to long
 
     public String filePath;
     public String uploadType; // e.g., "AUDIO_TRANSCRIPTION", "PHOTO_VISION"

--- a/app/src/main/java/com/drgraff/speakkey/data/UploadTaskDao.java
+++ b/app/src/main/java/com/drgraff/speakkey/data/UploadTaskDao.java
@@ -12,7 +12,7 @@ import java.util.List;
 public interface UploadTaskDao {
 
     @Insert
-    void insert(UploadTask task);
+    long insert(UploadTask task); // Changed from void to long
 
     @Update
     void update(UploadTask task);


### PR DESCRIPTION
Corrects type mismatches that caused build failures:
- Changed UploadTask.id from int to long.
- Updated UploadTaskDao.insert() to return long (the rowId).

These changes ensure that the taskId obtained from inserting an UploadTask into the database is correctly assigned to the UploadTask object and passed via intent extras, resolving the previous compilation errors in ShareDispatcherActivity.

This commit is part of the effort to improve shared audio handling and foregrounding.