### PR TITLE
Fix: Resolve IllegalStateException in ShareDispatcherActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -137,7 +137,7 @@
         <activity
             android:name=".ShareDispatcherActivity"
             android:label="Share to SpeakKey"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:theme="@style/Theme.SpeakKey.ShareDispatcher"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -129,4 +129,14 @@
         <item name="android:paddingLeft">16dp</item>
         <item name="android:paddingRight">16dp</item>
     </style>
+
+    <!-- Theme for ShareDispatcherActivity -->
+    <style name="Theme.SpeakKey.ShareDispatcher" parent="Theme.AppCompat.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">false</item> <!-- Typically false for full screen translucent -->
+        <item name="android:backgroundDimEnabled">false</item> <!-- Optional: if you don't want dimming -->
+    </style>
 </resources>


### PR DESCRIPTION
Changes the theme for ShareDispatcherActivity from the non-AppCompat Theme.Translucent.NoTitleBar to a custom AppCompat-compatible translucent theme (Theme.SpeakKey.ShareDispatcher).

This resolves the IllegalStateException ("You need to use a Theme.AppCompat theme (or descendant) with this activity") that occurred when ShareDispatcherActivity attempted to show a Toast or perform other UI operations after processing a shared item.