### PR TITLE
Fix: Refine prompt and parsing for one-step audio transcription

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/MainActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/MainActivity.java
@@ -1307,7 +1307,8 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         List<Prompt> activePrompts = promptManager.getPromptsForMode("one_step").stream().filter(Prompt::isActive).collect(Collectors.toList());
         String userPrompt = activePrompts.stream().map(Prompt::getText).collect(Collectors.joining("\n\n"));
         if (userPrompt.isEmpty()) {
-            userPrompt = "Please transcribe the audio file.  Do not add anything else before or after the transcribed text."; // Default prompt
+            // More explicit prompt for transcription
+            userPrompt = "Transcribe the following audio into text. Provide only the transcribed text and nothing else.";
         }
         final String finalUserPrompt = userPrompt;
         final String modelName = sharedPreferences.getString(SettingsActivity.PREF_KEY_ONESTEP_PROCESSING_MODEL, "gpt-4o"); // Default to gpt-4o or another suitable model


### PR DESCRIPTION
- Updated the default prompt in `MainActivity.transcribeAudioWithChatGpt()` to be more explicit about requiring a text transcription from the model.
- Adjusted response parsing in `ChatGptApi.getCompletionFromAudioAndPrompt()`:
    - Prioritizes `message.content` for the transcription.
    - If `message.content` is empty, it falls back to `message.audio.transcript`.
    - Added checks to ignore common placeholder values (e.g., '[Applause]', '[Music]') if they appear in `message.audio.transcript` and `message.content` is also empty, returning an empty string in such cases to avoid displaying placeholders as transcriptions.