### PR TITLE
Fix: Stricter audio format handling for One-Step shared audio

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/ShareDispatcherActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/ShareDispatcherActivity.java
@@ -131,17 +131,19 @@ public class ShareDispatcherActivity extends AppCompatActivity {
 
     SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
     String transcriptionMode = sharedPreferences.getString(SettingsActivity.PREF_KEY_TRANSCRIPTION_MODE, "two_step_transcription");
+    String transcriptionMode = sharedPreferences.getString(SettingsActivity.PREF_KEY_TRANSCRIPTION_MODE, "two_step_transcription");
     File fileToSendToMain = null;
 
-    // Prioritize file extension for MP3 check. Mime type can be misleading.
-    boolean isMp3Extension = "mp3".equalsIgnoreCase(fileExtension);
+    boolean isMp3ByExtension = "mp3".equalsIgnoreCase(fileExtension);
+    // Assume WAV contains PCM that LAME can process. Other compressed formats like M4A, OGG are problematic for current AudioUtils.
+    boolean isPotentiallyTranscodableByLame = "wav".equalsIgnoreCase(fileExtension);
 
     if ("one_step_transcription".equals(transcriptionMode)) {
-        if (isMp3Extension) {
-            Log.d(TAG, "One-Step: Shared audio has .mp3 extension. Using original copied file: " + copiedAudioFile.getName());
+        if (isMp3ByExtension) {
+            Log.d(TAG, "One-Step: Shared audio is MP3 by extension. Using copied file: " + copiedAudioFile.getName());
             fileToSendToMain = copiedAudioFile;
-        } else {
-            Log.d(TAG, "One-Step: Shared audio is not MP3 (Ext: " + fileExtension + ", MIME: " + originalMimeType + "). Attempting transcoding to MP3.");
+        } else if (isPotentiallyTranscodableByLame) {
+            Log.d(TAG, "One-Step: Shared audio is WAV (Ext: " + fileExtension + "). Attempting transcoding to MP3.");
             File cacheDir = getCacheDir();
             String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(new Date());
             String mp3FileName = "shared_audio_transcoded_" + timeStamp + ".mp3";
@@ -149,38 +151,48 @@ public class ShareDispatcherActivity extends AppCompatActivity {
             File transcodedMp3File = AudioUtils.convertToMp3(copiedAudioFile, mp3Output);
 
             if (transcodedMp3File != null && transcodedMp3File.exists() && transcodedMp3File.getName().toLowerCase().endsWith(".mp3")) {
-                Log.d(TAG, "One-Step: Transcoding to MP3 successful: " + transcodedMp3File.getAbsolutePath());
-                AppLogManager.getInstance().addEntry("INFO", TAG + ": One-Step: Transcoding to MP3 successful.", "New file: " + transcodedMp3File.getName());
+                Log.d(TAG, "One-Step: Transcoding WAV to MP3 successful: " + transcodedMp3File.getAbsolutePath());
+                AppLogManager.getInstance().addEntry("INFO", TAG + ": One-Step: WAV to MP3 transcoding successful.", "New file: " + transcodedMp3File.getName());
                 fileToSendToMain = transcodedMp3File;
                 if (!copiedAudioFile.delete()) {
-                    Log.w(TAG, "Failed to delete original non-MP3 temp file: " + copiedAudioFile.getAbsolutePath());
+                    Log.w(TAG, "Failed to delete original WAV temp file: " + copiedAudioFile.getAbsolutePath());
                 }
             } else {
-                Log.e(TAG, "One-Step: Failed to convert '" + copiedAudioFile.getName() + "' to MP3. AudioUtils.convertToMp3 might not support this format or failed.");
-                AppLogManager.getInstance().addEntry("ERROR", TAG + ": One-Step: MP3 transcoding failed for " + fileExtension, "Original File: " + copiedAudioFile.getName());
-                final String originalFormatForToast = (fileExtension != null && !fileExtension.isEmpty()) ? fileExtension.toUpperCase() : "audio";
-                runOnUiThread(() -> Toast.makeText(ShareDispatcherActivity.this, "Failed to convert " + originalFormatForToast + " to MP3 for One-Step. Please use an MP3 file or select Two-Step mode in settings.", Toast.LENGTH_LONG).show());
+                Log.e(TAG, "One-Step: Failed to convert WAV '" + copiedAudioFile.getName() + "' to MP3.");
+                AppLogManager.getInstance().addEntry("ERROR", TAG + ": One-Step: WAV to MP3 transcoding failed.", "Original File: " + copiedAudioFile.getName());
+                runOnUiThread(() -> Toast.makeText(ShareDispatcherActivity.this, "Failed to convert WAV to MP3 for One-Step. Please use an MP3 file or select Two-Step mode.", Toast.LENGTH_LONG).show());
                 finish();
-                return; // Abort
+                return;
             }
+        } else { // Is M4A, OGG, or other format not suitable for current AudioUtils's LAME direct processing
+            Log.e(TAG, "One-Step: Unsupported audio format '" + fileExtension + "' for direct MP3 conversion with current tools. Original file: " + copiedAudioFile.getName());
+            AppLogManager.getInstance().addEntry("ERROR", TAG + ": One-Step: Unsupported format for MP3 transcoding: " + fileExtension, "File: " + copiedAudioFile.getName());
+            final String originalFormatForToast = (fileExtension != null && !fileExtension.isEmpty()) ? fileExtension.toUpperCase() : "audio";
+            runOnUiThread(() -> Toast.makeText(ShareDispatcherActivity.this, "Cannot process " + originalFormatForToast + " for One-Step mode. Please use MP3/WAV or select Two-Step mode.", Toast.LENGTH_LONG).show());
+            finish();
+            return;
         }
 
-        // If we reach here for One-Step, fileToSendToMain should be a valid MP3
-        Log.d(TAG, "One-Step: Proceeding to MainActivity with MP3: " + fileToSendToMain.getAbsolutePath());
-        final File finalPathForMain = fileToSendToMain; // Effectively final for lambda
-        runOnUiThread(() -> {
-            Toast.makeText(ShareDispatcherActivity.this, "Audio prepared for One-Step processing...", Toast.LENGTH_LONG).show();
-            Intent mainActivityIntent = new Intent(ShareDispatcherActivity.this, MainActivity.class);
-            mainActivityIntent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-            mainActivityIntent.putExtra(MainActivity.EXTRA_SHARED_AUDIO_FILE_PATH, finalPathForMain.getAbsolutePath());
-            startActivity(mainActivityIntent);
-            finish();
-        });
+        // If fileToSendToMain is set, proceed to MainActivity for One-Step
+        if (fileToSendToMain != null) {
+            Log.d(TAG, "One-Step: Proceeding to MainActivity with MP3: " + fileToSendToMain.getAbsolutePath());
+            final File finalPathForMain = fileToSendToMain;
+            runOnUiThread(() -> {
+                Toast.makeText(ShareDispatcherActivity.this, "Audio prepared for One-Step processing...", Toast.LENGTH_LONG).show();
+                Intent mainActivityIntent = new Intent(ShareDispatcherActivity.this, MainActivity.class);
+                mainActivityIntent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+                mainActivityIntent.putExtra(MainActivity.EXTRA_SHARED_AUDIO_FILE_PATH, finalPathForMain.getAbsolutePath());
+                startActivity(mainActivityIntent);
+                finish();
+            });
+        }
+        // else, we've already called finish() and returned.
 
     } else { // Two-Step Transcription mode (or default)
-        File fileForTwoStep = copiedAudioFile; // Start with the original copied file
-        if (!isMp3Extension) { // If not an MP3 by extension, try to convert for Whisper robustness
-            Log.d(TAG, "Two-Step: Shared audio is not MP3 (Ext: " + fileExtension + "). Attempting transcoding for robust Whisper processing.");
+        File fileForTwoStep = copiedAudioFile;
+        if (!isMp3ByExtension) {
+            // For Two-Step, still attempt transcoding as Whisper might prefer MP3, but use original if it fails.
+            Log.d(TAG, "Two-Step: Shared audio is not MP3 (Ext: " + fileExtension + "). Attempting transcoding for Whisper.");
             File cacheDir = getCacheDir();
             String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(new Date());
             String mp3FileName = "shared_audio_transcoded_for_whisper_" + timeStamp + ".mp3";
@@ -194,11 +206,11 @@ public class ShareDispatcherActivity extends AppCompatActivity {
                     Log.w(TAG, "Failed to delete original non-MP3 temp file (two-step path): " + copiedAudioFile.getAbsolutePath());
                 }
             } else {
-                Log.w(TAG, "Two-Step: Transcoding to MP3 failed. Using original copied file for Whisper: " + copiedAudioFile.getName() + " (AudioUtils may not support this format for MP3 conversion).");
-                // fileForTwoStep remains copiedAudioFile, Whisper endpoint might handle it
+                Log.w(TAG, "Two-Step: Transcoding to MP3 failed for " + fileExtension + ". Using original copied file for Whisper: " + copiedAudioFile.getName());
+                // fileForTwoStep remains copiedAudioFile
             }
         } else {
-            Log.d(TAG, "Two-Step: Shared audio has .mp3 extension. Using original copied file: " + copiedAudioFile.getName());
+            Log.d(TAG, "Two-Step: Shared audio is MP3 by extension. Using original copied file: " + copiedAudioFile.getName());
         }
         processAsTwoStep(fileForTwoStep);
     }


### PR DESCRIPTION
- `ShareDispatcherActivity` now uses file extension to reliably identify MP3s.
- In "one_step_transcription" mode:
    - If shared audio is MP3, it's used directly.
    - If WAV, it attempts transcoding to MP3. If successful, the MP3 is used. If transcoding fails, an error is shown, and the process stops.
    - If M4A, OGG, or other formats not directly convertible to MP3 by current `AudioUtils` (LAME expecting PCM), it shows an error that the format is unsupported for One-Step and stops. It no longer attempts to transcode these unsupported formats with current tools for One-Step.
- This ensures that `MainActivity` only receives a valid MP3 path for the One-Step flow, preventing API errors due to format mismatches or garbled audio from improper transcoding attempts.
- The Two-Step flow remains more lenient, attempting MP3 conversion for non-MP3s but using the original file if conversion fails, relying on the Whisper endpoint's broader format support.