### PR TITLE
Fix: Remove duplicate transcriptionMode variable declaration

### DIFF
--- a/app/src/main/java/com/drgraff/speakkey/ShareDispatcherActivity.java
+++ b/app/src/main/java/com/drgraff/speakkey/ShareDispatcherActivity.java
@@ -131,7 +131,6 @@ public class ShareDispatcherActivity extends AppCompatActivity {
 
     SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
     String transcriptionMode = sharedPreferences.getString(SettingsActivity.PREF_KEY_TRANSCRIPTION_MODE, "two_step_transcription");
-    String transcriptionMode = sharedPreferences.getString(SettingsActivity.PREF_KEY_TRANSCRIPTION_MODE, "two_step_transcription");
     File fileToSendToMain = null;
 
     boolean isMp3ByExtension = "mp3".equalsIgnoreCase(fileExtension);


### PR DESCRIPTION
Removes the redundant declaration of the `transcriptionMode` variable in `ShareDispatcherActivity.handleSharedAudio` to resolve a compilation error.